### PR TITLE
Refactoring to separate user-specific and project-specific configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/build
 docs/source/modules.rst
 docs/source/pytest_wdl.rst
 docs/source/pytest_wdl.data_types.rst
+docs/source/pytest_wdl.executors.rst
 
 # Environments
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ cromwell-executions/
 __pycache__/
 *.pyc
 .coverage
+coverage.xml
 .idea
 docs/build
 docs/source/modules.rst

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+dist: xenial
+language: python
+cache:
+  directories:
+  - "$HOME/.cache/pip"
+python:
+  - "3.6"
+  - "3.7"
+install:
+- pip install --upgrade pip wheel
+- make install
+script:
+- make test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ pytestopts = -s -vv --show-capture=all
 
 BUILD = rm -Rf dist/* && python setup.py bdist_wheel && pip install --upgrade dist/*.whl $(installargs)
 INSTALL_EXTRAS = pip install .[all]
-TEST = env PYTHONPATH="." coverage run -m pytest -p pytester $(pytestopts) $(tests) ; coverage report -m
+TEST = env PYTHONPATH="." coverage run -m pytest -p pytester $(pytestopts) $(tests) ; coverage report -m ; coverage xml
 
 all:
 	$(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ tests = tests
 # Use this option to show full stack trace for errors
 #pytestopts = --full-trace
 #pytestopts = -ra --tb=short
-pytestopts = -vv --show-capture=all
+pytestopts = -s -vv --show-capture=all
 
 BUILD = rm -Rf dist/* && python setup.py bdist_wheel && pip install --upgrade dist/*.whl $(installargs)
 INSTALL_EXTRAS = pip install .[all]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pytest-wdl
 
-This package provides fixtures to enable writing tests that execute WDL workflows via Cromwell and check the generated output against expected values.
+This package is a plugin for the [pytest](https://docs.pytest.org/en/latest/) unit testing framework that enables testing of workflows written in [Workflow Description Language](https://github.com/openwdl).
 
 ## Dependencies
 
@@ -16,7 +16,7 @@ Other python dependencies are installed when you install the library.
 ### Install from PyPI
 
 ```commandline
-pip install pytest-wdl
+$ pip install pytest-wdl
 ```
 
 ### Install from source
@@ -24,48 +24,54 @@ pip install pytest-wdl
 You can to clone the repository and install:
 
 ```
-make install
+$ make install
 ```
 
 Or use pip to install from github:
 
 ```commandline
-pip install git+https://github.com/elilillyco/pytest-wdl.git
+$ pip install git+https://github.com/elilillyco/pytest-wdl.git
 ```
 
-### Installing Data Type Plugins
+### Install optional dependencies
 
-Data Types for expected output comparison are plugins. They are loaded on-demand and if they require external dependencies, you must install those.
+Some optional features of pytest-wdl have additional dependencies that are loaded on-demand. For example, to enable comparison of expected and actual BAM file outputs of a workflow, the [pysam](https://pysam.readthedocs.io/) library is required.
 
-The following data types require an extras installation:
+The following data types require an "extras" installation:
 
 - bam
 
 To install the dependencies for a data type that has extra dependencies:
 
-`pip install pytest-wdl[<data_type>]`
+```
+$ pip install pytest-wdl[<data_type>]
+```
 
 To do this locally, you can clone the repo and run:
 
-`pip install -e .[<data_type>]`
+```commandline
+$ pip install -e .[<data_type>]`
+```
 
 To install pytest-wdl and **all** extras dependencies:
 
-`pip install pytest-wdl[all]`
+```
+$ pip install pytest-wdl[all]
+```
 
 ## Usage
 
 The pytest-wdl plugin provides a set of fixtures for use with pytest. Here is a quick example:
 
 ```python
+# test_variant_caller.py
 def test_variant_caller(workflow_data, workflow_runner):
-    inputs = {
-        "bam": workflow_data["bam"],
-        "bai": workflow_data["bai"]
+    inputs = workflow_data.get_dict("bam", "bai")
+    inputs["index"] = {
+        "fasta": workflow_data["index_fa"],
+        "organism": "human"
     }
-    expected = {
-        "vcf": workflow_data["vcf"]
-    }
+    expected = workflow_data.get_dict("vcf")
     workflow_runner(
         "variant_caller/variant_caller.wdl",
         "call_variants",
@@ -74,163 +80,65 @@ def test_variant_caller(workflow_data, workflow_runner):
     )
 ```
 
-For details, [read the docs](docs/index.html).
+This test will execute a workflow (such as the following one) with the specified inputs, and will compare the outputs to the specified expected outputs.
 
-### Fixtures
+```wdl
+# variant_caller.wdl
+version 1.0
 
-The main fixtures are:
+struct Index {
+  File fasta
+  String organism
+}
 
-* workflow_data: Provides access to data files for use as inputs to a workflow, and for comparing to workflow output. Data files may be stored locally or remotely. The local cache directory may be specified using the `CACHE_DIR` environment variable; otherwise a temporary directory is used and is deleted at the end of the test session. Data are described in a JSON file. File data are described as a hash with the following keys.
-    * url: Optional; the remote URL.
-    * path: Optional; the local path to the file.
-    * contents: Optional; the contents of the file, specified as a string.
-    * name: Filename to use when localizing the file; also used when none of [url,path,contents] are defined to find the data file within the tests directory, using the same directory structure defined by the [pytest-datadir-ng](https://pypi.org/project/pytest-datadir-ng/) fixture.
-    * type: The file type. This is optional and only needs to be provided for certain types of files that are handled specially for the sake of comparison.
-    * allowed\_diff\_lines: Optional and only used for outputs comparison. If '0' or not specified, it is assumed that the expected and actual outputs are identical.
-    * http_headers: Optional dict mapping header names to environment variable names. These are the headers used in file download requests, and the environment variables can be used to specify the defaults.
-* cromwell_harness: Provides a CromwellHarness object that runs a WDL workflow using Cromwell with given inputs, parses out the results, and compares them against expected values. The `run_workflow` method has the following parameters:
-    * wdl_script: The WDL script to execute. The path should be relative to the project root.
-    * workflow_name: The name of the workflow in the WDL script.
-    * inputs: Object that will be serialized to JSON and provided to Cromwell as the workflow inputs.
-    * expected: Dict mapping output parameter names to expected values. For file outputs, the expected value can be specified as above (i.e. a URL, path, or contents). Any outputs that are not specified are ignored. This is an optional parameter and can be omitted if, for example, you only want to test that the workflow completes successfully.
-    * Additional keyword arguments:
-        * execution_dir: Directory in which to execute the workflow. Defaults to cwd. Ignored if `run_in_tempdir is True`. *Deprecated: will be removed in v1.0*
-        * inputs_file: Specify the inputs.json file to use, or the path to the inputs.json file to write, instead of a temp file.
-        * imports_file: Specify the imports file to use, or the path to the imports zip file to write, instead of a temp file.
-        * java_args: Override the default Java arguments.
-        * cromwell_args: Override the default Cromwell arguments.
-* workflow_runner: This is an alternative to cromwell_harness. It provides a callable and automatically determines the execution_dir based on the execution_dir fixture.
-
-There are also fixtures for specifying required inputs to the two main fixtures.
-
-* wdl_config_file: Provides the path to the user config file. Looks for the file path in the `WDL_CONFIG` environment variable, and falls back to looking for the file in the default location ($HOME/pytest_wdl_config.json).
-* wdl_config: Provides a session WdlConfig object that is boostrapped from the wdl_config_file if one is specified.
-* project_root: The root directory of the project. All relative paths are relative to this directory.
-* workflow_data_descriptor_file: Path to the JSON file that describes the test data. Defaults to `tests/test_data.json`.
-* workflow_data_descriptors: Mapping of test data names to values. Each value may be a primitive, a map describing a data file, or a DataFile object.
-* cache_dir: Local directory for caching test data. The `CACHE_DIR` environment variable takes precedence, otherwise by default this fixture creates a temporary directory that is used to cache test data for the test module.
-* execution_dir: Local directory in which tests are executed. The `EXECUTION_DIR` environment variable takes precedence, otherwise by default this fixture creates a temporary directory that is used to run the test function and is cleaned up afterwards.
-* http_headers: Dict mapping header names to environment variable names. These are the headers used in file download requests, and the environment variables can be used to specify the defaults.
-* proxies: Dict mapping proxy names to environment variables.
-* import_paths: Path to file that contains a list of WDL import paths (one per line). Defaults to `None`.
-* import_dirs: List of WDL import paths. Loads these from the file specified by `import_paths` if any, otherwise uses the parent directory of the test module.
-* java_bin: Path to the java executable. Defaults to `$JAVA_HOME/bin/java`.
-* java_args: String containing arguments to pass to Java.
-* cromwell_jar_file: By default this fixture first looks for the `$CROMWELL_JAR` enironment variable. It then searches the classpath for a JAR file that begins with 'cromwell' (case-insensitive). If the JAR file is not found in either place, it is expected to be located in the same directory as the tests are executed from (i.e. `./cromwell.jar`).
-* cromwell_args: String containing arguments to pass to Cromwell.
-
-These fixtures have sensible defaults, but can be overridden in two different ways:
-
-* Define them in the test module
-* Define them in a conftest.py module at or above the level of the test modules
-
-### Environment Variables
-
-The fixtures above can utilize environment variables. Technically, none are required and this can be run without them if your environment is setup to meet the needs of each fixture. Many can be set in other ways, like overriding a fixture. Below is a table of possible variables you can set though and which are recommended:
-
-| variable name | recommended | description |
-| ------------- | ----------- | ----------- |
-| `PYTEST_WDL_CONFIG`  | yes         | path to user config file; can also be specified to 
-| `PYTEST_WDL_CACHE_DIR` | no, use for testing and development | where to store test data, default is temp. If you define this, use an absolute path. |
-| `PYTEST_WDL_EXECUTION_DIR` | no, use for testing and development | where cromwell should execute, default is temp. If you define this, use an absolute path. | 
-| `LOGLEVEL` | no, use for debug | default is `WARNING`. Can set to `INFO`, `DEBUG`, `ERROR` to enable `pytest-wdl` logger output at various levels. |
-| `JAVA_HOME` | yes | path to java executable |
-| `CLASSPATH` | only if you do not specify `CROMWELL_JAR` | java classpath |
-| `CROMWELL_JAR` | yes         | path to cromwell jar. |
-| `CROMWELL_CONFIG` | no, only when needed | define a cromwell configuration file to use for the test run |
-| `CROMWELL_ARGS` | no, only when needed | add additional arguments into the cromwell run command |
-
-Remember that environment variables can be set multiple ways, including inline before running the command, such as `EXECUTION_DIR=$(pwd) python -m pytest -s tests/`
-
-### Workflow test data
-
-Workflow test data files can be provided by the `workflow_data` fixture, and are defined in the `test_data.json` file.
-
-#### test_data.json
-
-Test data is specified in a JSON file of the format:
-
-```json
-{
-  "name": {
-    "url": "http://foo.com/path/to/file",
-    "path": "localized/path",
-    "name": "filename",
-    "contents": "test",
-    "type": "vcf|bam",
-    "allowed_diff_lines": 2,
-    "http_headers": {
-      "header1": {
-        "env": "HEADER1",
-        "value": "FOOBAR"
-      }
-    }
+workflow call_variants {
+  input {
+    File bam
+    File bai
+    Index index
+  }
+  ...
+  output {
+    File vcf = variant_caller.vcf
   }
 }
 ```
 
-* url: Path to the file on a remote server from which it is downloaded if it can't be found locally; ignored if `fixture` is specified, or if the file already exists locally
-* path: Relative path to the file within the test data directory; ignored if `fixture` is specified
-* name: Name of the file - used when path is not specified, and also used to request the file from a location under the tests/ directory when it is in a directory structure as defined by the [pytest-datadir-ng](https://pypi.org/project/pytest-datadir-ng/) plugin.
-* contents: The contents of the file; the file will be written to `path` at runtime
-* type: For use with output data files; specifies the file type for special handling by a plugin
-* allowed_diff_lines: For use with output data files; specifies the number of lines that can be different between the actual and expected outputs and still have the test pass
-* http_headers: Map of http headers to add to the request when fetching contents from `url`. Keys are header names and values are maps consiting of one or both of two keys:
-    * env: The name of an environment variable to look in for the value.
-    * value: The value to use if `env` is not provided or the environment variable is unset.
+Input and output data are defined in a `test_data.json` file in the same directory as your test script:
 
-#### Data Types
-
-Available types:
-
-- default
-  - this is the default type if one is not specified. It can handle raw text files, as well as gzip compressed files.
-- vcf
-  - this considers only the first 5 columns in a VCF since the qual scores can vary slightly on different hardware.
-- bam*
-  - This converts BAM to SAM for diff comparison, enabling `allowed_diff_lines` usage since most BAM creation adds a command header or other comments that are expected to be different.
-  - This also replaces random UNSET-\w*\b type IDs that samtools often adds
-
-\* requires extra dependencies to be installed, see 
-[Installing Data Type Plugins](#installing-data-type-plugins)
-
-When comparing outputs of a test execution against an expected output file, that comparison is defined in the `expected` argument of the `workflow_runner`, where the key should be the output variable of the WDL workflow and the value is the expected value. This can be an accession into the workflow_data fixture, which resolves by looking at the test_data.json file. If the file is a binary format that requires special handling (not gzip, this is supported by default), such as BAM, =then we can specify that as the type (`"type": "bam"`) so that our comparison knows to convert that file into a temporary SAM file so we can do a diff. This enables specifying `allowed_diff_lines` attribute since BAM/SAM files often capture the command run as a header which will typically be different.
-
-The `type` attribute is ignored for input data files defined in workflow_data.
-
-##### Creating New Data Types
-
-To create a new data type plugin, add a module in the data_types directory.
-
-This should subclass the `pytest_wdl.core.DataFile` class and override its methods for _assert_contents_equal() and _diff to define the behavior for this file type.
-
-Next, add an entry point in setup.py. If the data type requires more dependencies be installed, make sure to use a Try/Except ImportError to warn about this and add the extra dependencies under the setup.py's `extras_require`. For example:
-
-```python
-setup(
-    ...,
-    entry_points={
-        "pytest_wdl": [
-            "bam = pytest_wdl.data_types.bam:BamDataFile"
-        ]
-    },
-    extras_require={
-        "bam": ["pysam"]
-    }
-)
+```json
+{
+  "bam": {
+    "url": "http://example.com/my.bam"
+  },
+  "bai": {
+    "url": "http://example.com/my.bam.bai"
+  },
+  "index_fa": {
+    "url": "http://example.com/GRCh38.fasta",
+    "path": "references/GRCh38.fasta"
+  },
+  "vcf": {
+    "url": "http://example.com/expected.vcf.gz",
+    "type": "vcf",
+    "allowed_diff_lines": 2
+  }
+}
 ```
 
-In this example, the extra dependencies can be installed with `pip install pytest-wdl[bam]`.
+For details, [read the docs](docs/index.html).
 
 ## Development
 
 To develop pytest-wdl, clone the repository and install all the dependencies:
 
-```
+```commandline
 $ git clone https://github.com/EliLillyCo/pytest-wdl.git
 $ pip install -r requirements.txt
 ```
 
 To run the full build and unit tests, run:
 
-`make`
+```commandline
+$ make
+```

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ Input and output data are defined in a `test_data.json` file in the same directo
     "url": "http://example.com/my.bam.bai"
   },
   "index_fa": {
-    "url": "http://example.com/GRCh38.fasta",
-    "path": "references/GRCh38.fasta"
+    "name": "chr22.fasta"
   },
   "vcf": {
     "url": "http://example.com/expected.vcf.gz",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx>=2.1.2
 recommonmark>=0.5.0
 sphinx_rtd_theme>=0.4.3
+sphinx-markdown-tables>=0.0.9

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinx_markdown_tables'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -46,7 +47,7 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 # add support for Markdown
 source_parsers = {
     '.md': 'recommonmark.parser.CommonMarkParser'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Welcome to pytest-wdl's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   manual.md
    modules.rst
 
 

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -1,0 +1,213 @@
+# User manual
+
+pytest-wdl is a plugin for the [pytest](https://docs.pytest.org/en/latest/) unit testing framework that enables testing of workflows written in [Workflow Description Language](https://github.com/openwdl). Test workflow inputs and expected outputs are [configured](#test_data) in a `test_data.json` file. Workflows are run by one or more [executors](#executors). By default, actual and expected outputs are compared by MD5 hash, but data type-specific comparisons are provided. Data types and executors are pluggable and can be provided via third-party packages. 
+
+## Fixtures
+
+All functionality of pytest-wdl is provided via [fixtures](https://docs.pytest.org/en/latest/fixture.html). As long as pytest-wdl is in your PYTHONPATH, its fixtures will be discovered and made available when you run pytest.
+
+The two most important fixtures are:
+
+* [workflow_data](#test_data): Provides access to data files for use as inputs to a workflow, and for comparing to workflow output.
+* [workflow_runner](#executors): Given a WDL workflow, inputs, and expected outputs, runs the workflow using one or more executors and compares actual and expected outputs.
+
+There are also [several additional fixtures](#configuration) used for configuration of the two main fixtures. In most cases, the default values returned by these fixtures "just work." However, if you need to override the defaults, you may do so either directly within your test modules, or in a [conftest.py](https://docs.pytest.org/en/2.7.3/plugins.html) file.
+
+## Test data
+
+Typically, workflows require inputs and generate outputs. Beyond simply ensuring that a workflow runs successfully, we often want to additionally test that it reproducibly generates the same results given the same inputs.
+
+Test inputs and outputs are configured in a `test_data.json` file that is stored in the same directory as the test module. This file has one entry for each input/output. Primitive types map as expected from JSON to Python to WDL. For example, the following `test_data.json` file defines an integer input that is loaded as a Python `int` and then maps to the WDL `Integer` type when passed as an input parameter to a workflow:
+
+```json
+{
+  "input_int": 42
+}
+```
+
+### Files
+
+For file inputs and outputs, pytest-wdl offers several different options. Test data files may be located remotely (identified by a URL), located within the test directory (using the folder hierarchy established by the [datadir-ng](https://pypi.org/project/pytest-datadir-ng/) plugin), located at an arbitrary local path, or defined by specifying the file contents directly within the JSON file. Files that do not already exist locally are localized on-demand and stored in the [cache directory](#cache).
+
+Some additional options are available only for expected outputs, in order to specify how they should be compared to the actual outputs.
+
+Below is an example `test_data.json` file that demonstrates different ways to define input and output data files:
+
+```json
+{
+  "bam": {
+    "url": "http://example.com/my.bam",
+    "http_headers": {
+      "auth_token": "TOKEN"
+    }
+  },
+  "reference": {
+    "path": "${REFERENCE_DIR}/chr22.fa"
+  },
+  "sample": {
+    "path": "samples.vcf",
+    "contents": "sample1\nsample2"
+  },
+  "output_vcf": {
+    "name": "output.vcf",
+    "type": "vcf",
+    "allowed_diff_lines": 2
+  }
+}
+```
+
+The available keys for configuring file inputs/outputs are:
+
+* name: Filename to use when localizing the file; when none of {url, path, contents} are defined, `name` is also used to search for the data file within the tests directory, using the same directory structure defined by the [datadir-ng](https://pypi.org/project/pytest-datadir-ng/) fixture.
+* path: The local path to the file. If the path does not already exist, the file will be localized to this path. Typically, this is defined as a relative path that will be prefixed with the [cache directory](#cache) path. Environment variables can be used to enable the user to configure an environment-specific path.
+* env: The name of an environment variable in which to look up the local path of the file.
+* url: A URL that can be resolved by [urllib](https://docs.python.org/3/library/urllib.html).
+    * http_headers: Optional dict mapping header names to values. These headers are used for file download requests. Keys are header names and values are either strings (environment variable name) or dict with the following keys:
+        * env: The name of an environment variable in which to look up the header value.
+        * value: The header value; only used if an environment variable is not specified or is unset.
+* contents: The contents of the file, specified as a string.
+
+In addition, 
+
+* type: The file type. This is optional and only needs to be provided for certain types of files that are handled specially for the sake of comparison.
+* allowed\_diff\_lines: Optional and only used for outputs comparison. If '0' or not specified, it is assumed that the expected and actual outputs are identical.
+
+
+* cromwell_harness: Provides a CromwellHarness object that runs a WDL workflow using Cromwell with given inputs, parses out the results, and compares them against expected values. The `run_workflow` method has the following parameters:
+    * wdl_script: The WDL script to execute. The path should be relative to the project root.
+    * workflow_name: The name of the workflow in the WDL script.
+    * inputs: Object that will be serialized to JSON and provided to Cromwell as the workflow inputs.
+    * expected: Dict mapping output parameter names to expected values. For file outputs, the expected value can be specified as above (i.e. a URL, path, or contents). Any outputs that are not specified are ignored. This is an optional parameter and can be omitted if, for example, you only want to test that the workflow completes successfully.
+    * Additional keyword arguments:
+        * execution_dir: Directory in which to execute the workflow. Defaults to cwd. Ignored if `run_in_tempdir is True`. *Deprecated: will be removed in v1.0*
+        * inputs_file: Specify the inputs.json file to use, or the path to the inputs.json file to write, instead of a temp file.
+        * imports_file: Specify the imports file to use, or the path to the imports zip file to write, instead of a temp file.
+        * java_args: Override the default Java arguments.
+        * cromwell_args: Override the default Cromwell arguments.
+* workflow_runner: This is an alternative to cromwell_harness. It provides a callable and automatically determines the execution_dir based on the execution_dir fixture.
+
+There are also fixtures for specifying required inputs to the two main fixtures.
+
+
+
+The local cache directory may be specified using the `CACHE_DIR` environment variable; otherwise a temporary directory is used and is deleted at the end of the test session. 
+
+
+* user_config_file: Provides the path to the user config file. Looks for the file path in the `user_config` environment variable, and falls back to looking for the file in the default location ($HOME/pytest_user_config.json).
+* user_config: Provides a session WdlConfig object that is boostrapped from the user_config_file if one is specified.
+* project_root: The root directory of the project. All relative paths are relative to this directory.
+* workflow_data_descriptor_file: Path to the JSON file that describes the test data. Defaults to `tests/test_data.json`.
+* workflow_data_descriptors: Mapping of test data names to values. Each value may be a primitive, a map describing a data file, or a DataFile object.
+* cache_dir: Local directory for caching test data. The `CACHE_DIR` environment variable takes precedence, otherwise by default this fixture creates a temporary directory that is used to cache test data for the test module.
+* execution_dir: Local directory in which tests are executed. The `EXECUTION_DIR` environment variable takes precedence, otherwise by default this fixture creates a temporary directory that is used to run the test function and is cleaned up afterwards.
+* http_headers: Dict mapping header names to environment variable names. These are the headers used in file download requests, and the environment variables can be used to specify the defaults.
+* proxies: Dict mapping proxy names to environment variables.
+* import_paths: Path to file that contains a list of WDL import paths (one per line). Defaults to `None`.
+* import_dirs: List of WDL import paths. Loads these from the file specified by `import_paths` if any, otherwise uses the parent directory of the test module.
+* java_bin: Path to the java executable. Defaults to `$JAVA_HOME/bin/java`.
+* java_args: String containing arguments to pass to Java.
+* cromwell_jar_file: By default this fixture first looks for the `$CROMWELL_JAR` enironment variable. It then searches the classpath for a JAR file that begins with 'cromwell' (case-insensitive). If the JAR file is not found in either place, it is expected to be located in the same directory as the tests are executed from (i.e. `./cromwell.jar`).
+* cromwell_args: String containing arguments to pass to Cromwell.
+
+These fixtures have sensible defaults, but can be overridden in two different ways:
+
+* Define them in the test module
+* Define them in a conftest.py module at or above the level of the test modules
+
+### Environment Variables
+
+The fixtures above can utilize environment variables. Technically, none are required and this can be run without them if your environment is setup to meet the needs of each fixture. Many can be set in other ways, like overriding a fixture. Below is a table of possible variables you can set though and which are recommended:
+
+| variable name | recommended | description |
+| ------------- | ----------- | ----------- |
+| `PYTEST_user_config`  | yes         | path to user config file; can also be specified to 
+| `PYTEST_WDL_CACHE_DIR` | no, use for testing and development | where to store test data, default is temp. If you define this, use an absolute path. |
+| `PYTEST_WDL_EXECUTION_DIR` | no, use for testing and development | where cromwell should execute, default is temp. If you define this, use an absolute path. | 
+| `LOGLEVEL` | no, use for debug | default is `WARNING`. Can set to `INFO`, `DEBUG`, `ERROR` to enable `pytest-wdl` logger output at various levels. |
+| `JAVA_HOME` | yes | path to java executable |
+| `CLASSPATH` | only if you do not specify `CROMWELL_JAR` | java classpath |
+| `CROMWELL_JAR` | yes         | path to cromwell jar. |
+| `CROMWELL_CONFIG` | no, only when needed | define a cromwell configuration file to use for the test run |
+| `CROMWELL_ARGS` | no, only when needed | add additional arguments into the cromwell run command |
+
+Remember that environment variables can be set multiple ways, including inline before running the command, such as `EXECUTION_DIR=$(pwd) python -m pytest -s tests/`
+
+### Workflow test data
+
+Workflow test data files can be provided by the `workflow_data` fixture, and are defined in the `test_data.json` file.
+
+#### test_data.json
+
+Test data is specified in a JSON file of the format:
+
+```json
+{
+  "name": {
+    "url": "http://foo.com/path/to/file",
+    "path": "localized/path",
+    "name": "filename",
+    "contents": "test",
+    "type": "vcf|bam",
+    "allowed_diff_lines": 2,
+    "http_headers": {
+      "header1": {
+        "env": "HEADER1",
+        "value": "FOOBAR"
+      }
+    }
+  }
+}
+```
+
+* url: Path to the file on a remote server from which it is downloaded if it can't be found locally; ignored if `fixture` is specified, or if the file already exists locally
+* path: Relative path to the file within the test data directory; ignored if `fixture` is specified
+* name: Name of the file - used when path is not specified, and also used to request the file from a location under the tests/ directory when it is in a directory structure as defined by the [pytest-datadir-ng](https://pypi.org/project/pytest-datadir-ng/) plugin.
+* contents: The contents of the file; the file will be written to `path` at runtime
+* type: For use with output data files; specifies the file type for special handling by a plugin
+* allowed_diff_lines: For use with output data files; specifies the number of lines that can be different between the actual and expected outputs and still have the test pass
+* http_headers: Map of http headers to add to the request when fetching contents from `url`. Keys are header names and values are maps consiting of one or both of two keys:
+    * env: The name of an environment variable to look in for the value.
+    * value: The value to use if `env` is not provided or the environment variable is unset.
+
+#### Data Types
+
+Available types:
+
+- default
+  - this is the default type if one is not specified. It can handle raw text files, as well as gzip compressed files.
+- vcf
+  - this considers only the first 5 columns in a VCF since the qual scores can vary slightly on different hardware.
+- bam*
+  - This converts BAM to SAM for diff comparison, enabling `allowed_diff_lines` usage since most BAM creation adds a command header or other comments that are expected to be different.
+  - This also replaces random UNSET-\w*\b type IDs that samtools often adds
+
+\* requires extra dependencies to be installed, see 
+[Installing Data Type Plugins](#installing-data-type-plugins)
+
+When comparing outputs of a test execution against an expected output file, that comparison is defined in the `expected` argument of the `workflow_runner`, where the key should be the output variable of the WDL workflow and the value is the expected value. This can be an accession into the workflow_data fixture, which resolves by looking at the test_data.json file. If the file is a binary format that requires special handling (not gzip, this is supported by default), such as BAM, =then we can specify that as the type (`"type": "bam"`) so that our comparison knows to convert that file into a temporary SAM file so we can do a diff. This enables specifying `allowed_diff_lines` attribute since BAM/SAM files often capture the command run as a header which will typically be different.
+
+The `type` attribute is ignored for input data files defined in workflow_data.
+
+##### Creating New Data Types
+
+To create a new data type plugin, add a module in the data_types directory.
+
+This should subclass the `pytest_wdl.core.DataFile` class and override its methods for _assert_contents_equal() and _diff to define the behavior for this file type.
+
+Next, add an entry point in setup.py. If the data type requires more dependencies be installed, make sure to use a Try/Except ImportError to warn about this and add the extra dependencies under the setup.py's `extras_require`. For example:
+
+```python
+setup(
+    ...,
+    entry_points={
+        "pytest_wdl": [
+            "bam = pytest_wdl.data_types.bam:BamDataFile"
+        ]
+    },
+    extras_require={
+        "bam": ["pysam"]
+    }
+)
+```
+
+In this example, the extra dependencies can be installed with `pip install pytest-wdl[bam]`.

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -157,6 +157,7 @@ The available configuration options are listed in the following table:
 | `execution_dir` | `PYTEST_WDL_EXECUTION_DIR` | Directory in which tests are executed | Temporary directory; a separate directory is used for each test function | Only use for debugging; use an absolute path |
 | `proxies` | Configurable | Proxy server information; see details below | None | Use environment variable(s) to configure your proxy server(s), if any |
 | `http_headers` | Configurable | HTTP header configuration that applies to all URLs matching a given pattern; see details below | None | Configure headers by URL pattern; configure headers for specific URLs in the test_data.json file |
+| `show_progress` | N/A | Whether to show progress bars when downloading files | False | |
 | `executors` |Executor-dependent | Configuration options specific to each executor; see below | None | |
 | N/A | `LOGLEVEL` | Level of detail to log; can set to 'DEBUG', 'INFO', 'WARNING', or 'ERROR' | 'WARNING' | Use 'DEBUG' when developing plugins/fixtures/etc., otherwise 'WARNING' |
 

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -65,29 +65,73 @@ The available keys for configuring file inputs/outputs are:
     * http_headers: Optional dict mapping header names to values. These headers are used for file download requests. Keys are header names and values are either strings (environment variable name) or dict with the following keys:
         * env: The name of an environment variable in which to look up the header value.
         * value: The header value; only used if an environment variable is not specified or is unset.
-* contents: The contents of the file, specified as a string.
+* contents: The contents of the file, specified as a string. The file is written to `path` the first time it is requested.
 
-In addition, 
+In addition, the following keys are recognized for output files only:
 
 * type: The file type. This is optional and only needs to be provided for certain types of files that are handled specially for the sake of comparison.
 * allowed\_diff\_lines: Optional and only used for outputs comparison. If '0' or not specified, it is assumed that the expected and actual outputs are identical.
 
+#### Data Types
 
-* cromwell_harness: Provides a CromwellHarness object that runs a WDL workflow using Cromwell with given inputs, parses out the results, and compares them against expected values. The `run_workflow` method has the following parameters:
-    * wdl_script: The WDL script to execute. The path should be relative to the project root.
-    * workflow_name: The name of the workflow in the WDL script.
-    * inputs: Object that will be serialized to JSON and provided to Cromwell as the workflow inputs.
-    * expected: Dict mapping output parameter names to expected values. For file outputs, the expected value can be specified as above (i.e. a URL, path, or contents). Any outputs that are not specified are ignored. This is an optional parameter and can be omitted if, for example, you only want to test that the workflow completes successfully.
-    * Additional keyword arguments:
-        * execution_dir: Directory in which to execute the workflow. Defaults to cwd. Ignored if `run_in_tempdir is True`. *Deprecated: will be removed in v1.0*
-        * inputs_file: Specify the inputs.json file to use, or the path to the inputs.json file to write, instead of a temp file.
-        * imports_file: Specify the imports file to use, or the path to the imports zip file to write, instead of a temp file.
-        * java_args: Override the default Java arguments.
-        * cromwell_args: Override the default Cromwell arguments.
-* workflow_runner: This is an alternative to cromwell_harness. It provides a callable and automatically determines the execution_dir based on the execution_dir fixture.
+When comparing actual and expected outputs, the "type" of the expected output is used to determine how the files are compared. If no type is specified, then the type is assumed to be "default."
 
-There are also fixtures for specifying required inputs to the two main fixtures.
+Available types:
 
+- default: The default type if one is not specified.
+    - It can handle raw text files, as well as gzip compressed files.
+    - If `allowed_diff_lines` is 0 or not specified, then the files are compared by their MD5 hashes.
+    - If `allowed_diff_lines` is > 0, the files are converted to text and compared using the linux `diff` tool.
+- vcf: During comparison, headers are ignored, as are the QUAL, INFO, and FORMAT columns; for sample columns, only the first sample column is compared between files, and only the genotype values for that sample.
+- bam*:
+  - BAM is converted to SAM and headers are ignored.
+  - Replaces random UNSET-\w*\b type IDs that samtools often adds.
+
+\* requires extra dependencies to be installed, see 
+[Installing Data Type Plugins](#installing-data-type-plugins)
+
+## Executors
+
+An Executor is a wrapper around a WDL workflow execution engine that prepares inputs, runs the tool, captures outputs, and handles errors. Currently, [Cromwell](https://cromwell.readthedocs.io/) is the only supported executor, but aternative executors can be implemented as [plugins](#plugins).
+
+The `workflow_runner` fixture is a callable that runs the workflow using the executor. It takes one required arguments and several additional optional arguments:
+
+* wdl_script: Required; the WDL script to execute. The path must either be absolute or (more commonly) relative to the project root.
+* workflow_name: The name of the workflow to execute in the WDL script. If not specified, it is assumed that the workflow has the same name as the WDL file (without the ".wdl" extension).
+* inputs: Dict that will be serialized to JSON and provided to Cromwell as the workflow inputs. If not specified, the workflow must not have any required inputs.
+* expected: Dict mapping output parameter names to expected values. Any workflow outputs that are not specified are ignored. This is an optional parameter and can be omitted if, for example, you only want to test that the workflow completes successfully.
+
+### Executor-specific options
+
+#### Cromwell
+
+* inputs_file: Specify the inputs.json file to use, or the path to the inputs.json file to write, instead of a temp file.
+* imports_file: Specify the imports file to use, or the path to the imports zip file to write, instead of a temp file.
+* java_args: Override the default Java arguments.
+* cromwell_args: Override the default Cromwell arguments.
+
+## Configuration
+
+pytest-wdl has two levels of configuration: 
+
+* Project-specific configuration, which generally deals with the structure of the project, and may require customization if the structure of your project differs substantially from what is expected, but also encompases executor-specific configuration.
+* Environment-specific configuration, which generally deals with idiosyncrasies of the local environment.
+
+### Project-specific configuration
+
+Configuration at the project level is handled by overriding fixtures, either in the test module or in a top-level conftest.py file. The following fixtures may be overridden:
+
+| fixture name | scope | description | default |
+| -------------| ----- | ----------- | ------- |
+| `project_root_files` | module | List of filenames that are found in the project root directory. | `["setup.py", "pyproject.toml", ".git"]`
+| `project_root` | module | The root directory of the project. Relative paths are relative to this directory, unless specified otherwise. | Starting in the current test directory/module, scan up the directory hierarchy until one of the `project_root_files` are located. |
+| `workflow_data_descriptor_file` | module | Path to the JSON file that describes the test data. | `tests/test_data.json` |
+| `workflow_data_descriptors` | module | Mapping of workflow input/output names to values (as described in the [Files](#files) section). | Loaded from the `workflow_data_descriptor_file` |
+| `workflow_data_resolver` | module | Provides the `DataResolver` object that resolves test data; this should only need to be overridden for testing/debugging purposes | `DataResolver` created from `workflow_data_descriptors` |
+| `import_paths` | module | Provides the path to the file that lists the directories from which to import WDL dependencies | "import_paths.txt" |
+| `import_dirs` | module | Provides the directories from which to import WDL dependencies | Loaded from `import_paths` file, if any |
+
+### Environment-specific configuration
 
 
 The local cache directory may be specified using the `CACHE_DIR` environment variable; otherwise a temporary directory is used and is deleted at the end of the test session. 
@@ -95,26 +139,22 @@ The local cache directory may be specified using the `CACHE_DIR` environment var
 
 * user_config_file: Provides the path to the user config file. Looks for the file path in the `user_config` environment variable, and falls back to looking for the file in the default location ($HOME/pytest_user_config.json).
 * user_config: Provides a session WdlConfig object that is boostrapped from the user_config_file if one is specified.
-* project_root: The root directory of the project. All relative paths are relative to this directory.
-* workflow_data_descriptor_file: Path to the JSON file that describes the test data. Defaults to `tests/test_data.json`.
-* workflow_data_descriptors: Mapping of test data names to values. Each value may be a primitive, a map describing a data file, or a DataFile object.
+
 * cache_dir: Local directory for caching test data. The `CACHE_DIR` environment variable takes precedence, otherwise by default this fixture creates a temporary directory that is used to cache test data for the test module.
 * execution_dir: Local directory in which tests are executed. The `EXECUTION_DIR` environment variable takes precedence, otherwise by default this fixture creates a temporary directory that is used to run the test function and is cleaned up afterwards.
 * http_headers: Dict mapping header names to environment variable names. These are the headers used in file download requests, and the environment variables can be used to specify the defaults.
 * proxies: Dict mapping proxy names to environment variables.
-* import_paths: Path to file that contains a list of WDL import paths (one per line). Defaults to `None`.
-* import_dirs: List of WDL import paths. Loads these from the file specified by `import_paths` if any, otherwise uses the parent directory of the test module.
+
 * java_bin: Path to the java executable. Defaults to `$JAVA_HOME/bin/java`.
-* java_args: String containing arguments to pass to Java.
 * cromwell_jar_file: By default this fixture first looks for the `$CROMWELL_JAR` enironment variable. It then searches the classpath for a JAR file that begins with 'cromwell' (case-insensitive). If the JAR file is not found in either place, it is expected to be located in the same directory as the tests are executed from (i.e. `./cromwell.jar`).
-* cromwell_args: String containing arguments to pass to Cromwell.
+
 
 These fixtures have sensible defaults, but can be overridden in two different ways:
 
 * Define them in the test module
 * Define them in a conftest.py module at or above the level of the test modules
 
-### Environment Variables
+#### Environment Variables
 
 The fixtures above can utilize environment variables. Technically, none are required and this can be run without them if your environment is setup to meet the needs of each fixture. Many can be set in other ways, like overriding a fixture. Below is a table of possible variables you can set though and which are recommended:
 
@@ -132,63 +172,9 @@ The fixtures above can utilize environment variables. Technically, none are requ
 
 Remember that environment variables can be set multiple ways, including inline before running the command, such as `EXECUTION_DIR=$(pwd) python -m pytest -s tests/`
 
-### Workflow test data
+## Plugins
 
-Workflow test data files can be provided by the `workflow_data` fixture, and are defined in the `test_data.json` file.
-
-#### test_data.json
-
-Test data is specified in a JSON file of the format:
-
-```json
-{
-  "name": {
-    "url": "http://foo.com/path/to/file",
-    "path": "localized/path",
-    "name": "filename",
-    "contents": "test",
-    "type": "vcf|bam",
-    "allowed_diff_lines": 2,
-    "http_headers": {
-      "header1": {
-        "env": "HEADER1",
-        "value": "FOOBAR"
-      }
-    }
-  }
-}
-```
-
-* url: Path to the file on a remote server from which it is downloaded if it can't be found locally; ignored if `fixture` is specified, or if the file already exists locally
-* path: Relative path to the file within the test data directory; ignored if `fixture` is specified
-* name: Name of the file - used when path is not specified, and also used to request the file from a location under the tests/ directory when it is in a directory structure as defined by the [pytest-datadir-ng](https://pypi.org/project/pytest-datadir-ng/) plugin.
-* contents: The contents of the file; the file will be written to `path` at runtime
-* type: For use with output data files; specifies the file type for special handling by a plugin
-* allowed_diff_lines: For use with output data files; specifies the number of lines that can be different between the actual and expected outputs and still have the test pass
-* http_headers: Map of http headers to add to the request when fetching contents from `url`. Keys are header names and values are maps consiting of one or both of two keys:
-    * env: The name of an environment variable to look in for the value.
-    * value: The value to use if `env` is not provided or the environment variable is unset.
-
-#### Data Types
-
-Available types:
-
-- default
-  - this is the default type if one is not specified. It can handle raw text files, as well as gzip compressed files.
-- vcf
-  - this considers only the first 5 columns in a VCF since the qual scores can vary slightly on different hardware.
-- bam*
-  - This converts BAM to SAM for diff comparison, enabling `allowed_diff_lines` usage since most BAM creation adds a command header or other comments that are expected to be different.
-  - This also replaces random UNSET-\w*\b type IDs that samtools often adds
-
-\* requires extra dependencies to be installed, see 
-[Installing Data Type Plugins](#installing-data-type-plugins)
-
-When comparing outputs of a test execution against an expected output file, that comparison is defined in the `expected` argument of the `workflow_runner`, where the key should be the output variable of the WDL workflow and the value is the expected value. This can be an accession into the workflow_data fixture, which resolves by looking at the test_data.json file. If the file is a binary format that requires special handling (not gzip, this is supported by default), such as BAM, =then we can specify that as the type (`"type": "bam"`) so that our comparison knows to convert that file into a temporary SAM file so we can do a diff. This enables specifying `allowed_diff_lines` attribute since BAM/SAM files often capture the command run as a header which will typically be different.
-
-The `type` attribute is ignored for input data files defined in workflow_data.
-
-##### Creating New Data Types
+### Creating new data types
 
 To create a new data type plugin, add a module in the data_types directory.
 
@@ -211,3 +197,6 @@ setup(
 ```
 
 In this example, the extra dependencies can be installed with `pip install pytest-wdl[bam]`.
+
+### Creating new executors
+

--- a/examples/pytest_wdl_config.json
+++ b/examples/pytest_wdl_config.json
@@ -1,0 +1,28 @@
+{
+  "cache_dir": "/tmp/wdl_cache",
+  "proxies": {
+    "http": {
+      "value": "http://foo.com/proxy",
+      "env": "HTTP_PROXY"
+    },
+    "https": {
+      "value": "https://foo.com/proxy",
+      "env": "HTTPS_PROXY"
+    }
+  },
+  "http_headers": [
+    {
+      "name": "X-JFrog-Art-Api",
+      "pattern": "http://my.company.com/artifactory/*",
+      "env": "TOKEN"
+    }
+  ],
+  "executors": {
+    "cromwell": {
+      "java_bin": "/usr/local/bin/java",
+      "java_args": "-Xmx8g",
+      "cromwell_jar": "/usr/local/opt/cromwell/Cromwell-44.jar",
+      "cromwell_args": "-Ddocker.hash-lookup.enabled=false"
+    }
+  }
+}

--- a/pytest_wdl/__init__.py
+++ b/pytest_wdl/__init__.py
@@ -7,8 +7,8 @@ from pytest_wdl import fixtures
 import pytest
 
 
-wdl_config_file = pytest.fixture(scope="session")(fixtures.wdl_config_file)
-wdl_config = pytest.fixture(scope="session")(fixtures.wdl_config)
+user_config_file = pytest.fixture(scope="session")(fixtures.user_config_file)
+user_config = pytest.fixture(scope="session")(fixtures.user_config)
 project_root_files = pytest.fixture(scope="module")(fixtures.project_root_files)
 project_root = pytest.fixture(scope="module")(fixtures.project_root)
 workflow_data_descriptor_file = pytest.fixture(scope="module")(fixtures.workflow_data_descriptor_file)

--- a/pytest_wdl/__init__.py
+++ b/pytest_wdl/__init__.py
@@ -7,24 +7,22 @@ from pytest_wdl import fixtures
 import pytest
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--wdl-config", default=None,
+        help="Path to JSON file with environment-specifc configuration."
+    )
+
+
+wdl_config_file = pytest.fixture(scope="session")(fixtures.wdl_config_file)
 project_root_files = pytest.fixture(scope="module")(fixtures.project_root_files)
 project_root = pytest.fixture(scope="module")(fixtures.project_root)
 workflow_data_descriptor_file = pytest.fixture(scope="module")(fixtures.workflow_data_descriptor_file)
 workflow_data_descriptors = pytest.fixture(scope="module")(fixtures.workflow_data_descriptors)
-cache_dir = pytest.fixture(scope="module")(fixtures.cache_dir)
-execution_dir = pytest.fixture(scope="function")(fixtures.execution_dir)
-http_header_map = pytest.fixture(scope="session")(fixtures.http_header_map)
-http_headers = pytest.fixture(scope="session")(fixtures.http_headers)
-proxy_map = pytest.fixture(scope="session")(fixtures.proxy_map)
-proxies = pytest.fixture(scope="session")(fixtures.proxies)
-import_paths = pytest.fixture(scope="module")(fixtures.import_paths)
-import_dirs = pytest.fixture(scope="module")(fixtures.import_dirs)
-java_bin = pytest.fixture(scope="session")(fixtures.java_bin)
-cromwell_config_file = pytest.fixture(scope="session")(fixtures.cromwell_config_file)
-java_args = pytest.fixture(scope="session")(fixtures.java_args)
-cromwell_jar_file = pytest.fixture(scope="session")(fixtures.cromwell_jar_file)
-cromwell_args = pytest.fixture(scope="session")(fixtures.cromwell_args)
 workflow_data_resolver = pytest.fixture(scope="module")(fixtures.workflow_data_resolver)
 workflow_data = pytest.fixture(scope="function")(fixtures.workflow_data)
+import_paths = pytest.fixture(scope="module")(fixtures.import_paths)
+import_dirs = pytest.fixture(scope="module")(fixtures.import_dirs)
+cromwell_config = pytest.fixture(scope="session")(fixtures.cromwell_config)
 cromwell_harness = pytest.fixture(scope="module")(fixtures.cromwell_harness)
 workflow_runner = pytest.fixture(scope="function")(fixtures.workflow_runner)

--- a/pytest_wdl/__init__.py
+++ b/pytest_wdl/__init__.py
@@ -7,13 +7,6 @@ from pytest_wdl import fixtures
 import pytest
 
 
-def pytest_addoption(parser):
-    parser.addoption(
-        "--wdl-config", default=None,
-        help="Path to JSON file with environment-specifc configuration."
-    )
-
-
 wdl_config_file = pytest.fixture(scope="session")(fixtures.wdl_config_file)
 wdl_config = pytest.fixture(scope="session")(fixtures.wdl_config)
 project_root_files = pytest.fixture(scope="module")(fixtures.project_root_files)

--- a/pytest_wdl/__init__.py
+++ b/pytest_wdl/__init__.py
@@ -15,6 +15,7 @@ def pytest_addoption(parser):
 
 
 wdl_config_file = pytest.fixture(scope="session")(fixtures.wdl_config_file)
+wdl_config = pytest.fixture(scope="session")(fixtures.wdl_config)
 project_root_files = pytest.fixture(scope="module")(fixtures.project_root_files)
 project_root = pytest.fixture(scope="module")(fixtures.project_root)
 workflow_data_descriptor_file = pytest.fixture(scope="module")(fixtures.workflow_data_descriptor_file)
@@ -23,6 +24,5 @@ workflow_data_resolver = pytest.fixture(scope="module")(fixtures.workflow_data_r
 workflow_data = pytest.fixture(scope="function")(fixtures.workflow_data)
 import_paths = pytest.fixture(scope="module")(fixtures.import_paths)
 import_dirs = pytest.fixture(scope="module")(fixtures.import_dirs)
-cromwell_config = pytest.fixture(scope="session")(fixtures.cromwell_config)
-cromwell_harness = pytest.fixture(scope="module")(fixtures.cromwell_harness)
+cromwell_executor = pytest.fixture(scope="module")(fixtures.cromwell_executor)
 workflow_runner = pytest.fixture(scope="function")(fixtures.workflow_runner)

--- a/pytest_wdl/__init__.py
+++ b/pytest_wdl/__init__.py
@@ -17,5 +17,4 @@ workflow_data_resolver = pytest.fixture(scope="module")(fixtures.workflow_data_r
 workflow_data = pytest.fixture(scope="function")(fixtures.workflow_data)
 import_paths = pytest.fixture(scope="module")(fixtures.import_paths)
 import_dirs = pytest.fixture(scope="module")(fixtures.import_dirs)
-cromwell_executor = pytest.fixture(scope="module")(fixtures.cromwell_executor)
 workflow_runner = pytest.fixture(scope="function")(fixtures.workflow_runner)

--- a/pytest_wdl/core.py
+++ b/pytest_wdl/core.py
@@ -473,8 +473,20 @@ class DataManager:
         self.data_resolver = data_resolver
         self.datadirs = datadirs
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str):
         return self.data_resolver.resolve(name, self.datadirs)
+
+    def get_dict(self, *names: str) -> dict:
+        """
+        Creates a dict with one or more entries from this DataManager.
+
+        Args:
+            *names: Names of test data entries to add to the dict.
+
+        Returns:
+            Dict mapping `name` to `self[name]` for all specified names.
+        """
+        return {name: self[name] for name in names}
 
 
 class Executor(metaclass=ABCMeta):

--- a/pytest_wdl/core.py
+++ b/pytest_wdl/core.py
@@ -48,6 +48,7 @@ class WdlConfig:
                 cache_dir = ensure_path(cache_dir_str)
         if cache_dir:
             self.cache_dir = ensure_path(cache_dir, is_file=False, create=True)
+            self.remove_cache_dir = False
         else:
             self.cache_dir = Path(tempfile.mkdtemp())
             self.remove_cache_dir = True

--- a/pytest_wdl/data_types/bam.py
+++ b/pytest_wdl/data_types/bam.py
@@ -50,15 +50,15 @@ class BamDataFile(DataFile):
 
 def _bam_to_sam(input_bam: Path, output_sam: Path):
     """Use PySAM to convert bam to sam."""
-    samfile = pysam.view('-h', str(input_bam))
+    samfile = pysam.view("-h", str(input_bam))
     # avoid trailing newline.
-    newline = ''
-    with open(output_sam, 'w') as file_handle:
+    newline = ""
+    with open(output_sam, "w") as file_handle:
         for row in samfile.splitlines():
             file_handle.write(newline + _remove_samtools_randomness(row))
-            newline = '\n'
+            newline = "\n"
 
 
 def _remove_samtools_randomness(sam_line):
     """Replace the random IDs added by samtools."""
-    return re.sub(r'UNSET-\w*\b', 'UNSET-placeholder', sam_line)
+    return re.sub(r"UNSET-\w*\b", "UNSET-placeholder", sam_line)

--- a/pytest_wdl/data_types/vcf.py
+++ b/pytest_wdl/data_types/vcf.py
@@ -23,7 +23,8 @@ class VcfDataFile(DataFile):
     @classmethod
     def _diff(cls, file1: Path, file2: Path):
         """
-        Special handling for VCF files to only compare the first 5 columns.
+        Special handling for VCF files to ignore QUAL, INFO, and FORMAT, and only
+        compares genotypes in the first sample column
 
         Args:
             file1: First file to compare

--- a/pytest_wdl/executors/__init__.py
+++ b/pytest_wdl/executors/__init__.py
@@ -1,0 +1,129 @@
+import glob
+import json
+from pathlib import Path
+import tempfile
+from typing import List, Optional, Tuple, Union
+
+import delegator
+
+from pytest_wdl.core import DataFile
+from pytest_wdl.utils import LOG, ensure_path, safe_string
+
+
+def get_workflow(
+    project_root: Path, wdl_file: Union[str, Path], workflow_name: Optional[str] = None
+) -> Tuple[Path, str]:
+    """
+    Resolve the WDL file and workflow name.
+
+    TODO: if `workflow_name` is None, parse the WDL file and extract the name
+     of the workflow.
+
+    Args:
+        project_root: The root directory to which `wdl_file` might be relative.
+        wdl_file: Path to the WDL file.
+        workflow_name: The workflow name; if None, the filename without ".wdl"
+            extension is used.
+
+    Returns:
+        A tuple (wdl_path, workflow_name)
+    """
+    wdl_path = ensure_path(wdl_file, project_root, canonicalize=True)
+    if not wdl_path.exists():
+        raise FileNotFoundError(f"WDL file not found at path {wdl_path}")
+
+    if not workflow_name:
+        workflow_name = safe_string(wdl_path.stem)
+
+    return wdl_path, workflow_name
+
+
+def get_workflow_inputs(
+    workflow_name: str, inputs_dict: Optional[dict] = None,
+    inputs_file: Optional[Path] = None
+) -> Tuple[dict, Path]:
+    """
+    Persist workflow inputs to a file, or load workflow inputs from a file.
+
+    Args:
+        workflow_name: Name of the workflow; used to prefix the input parameters when
+            creating the inputs file from the inputs dict.
+        inputs_dict: Dict of input names/values.
+        inputs_file: JSON file with workflow inputs.
+
+    Returns:
+        A tuple (inputs_dict, inputs_file)
+    """
+    if inputs_file:
+        inputs_file = ensure_path(inputs_file)
+        if inputs_file.exists():
+            with open(inputs_file, "rt") as inp:
+                inputs_dict = json.load(inp)
+                return inputs_dict, inputs_file
+
+    if inputs_dict:
+        inputs_dict = dict(
+            (
+                f"{workflow_name}.{key}",
+                value.path if isinstance(value, DataFile) else value
+            )
+            for key, value in inputs_dict.items()
+        )
+
+        if inputs_file:
+            inputs_file = ensure_path(inputs_file, is_file=True, create=True)
+        else:
+            inputs_file = Path(tempfile.mkstemp(suffix=".json")[1])
+
+        with open(inputs_file, "wt") as out:
+            json.dump(inputs_dict, out, default=str)
+
+    return inputs_dict, inputs_file
+
+
+def get_workflow_imports(
+    import_dirs: Optional[List[Path]] = None, imports_file: Optional[Path] = None
+) -> Path:
+    """
+    Creates a ZIP file with all WDL files to be imported.
+
+    Args:
+        import_dirs: Directories from which to import WDL files.
+        imports_file: Text file naming import directories/files - one per line.
+
+    Returns:
+        Path to the ZIP file.
+    """
+    write_imports = bool(import_dirs)
+    imports_path = None
+
+    if imports_file:
+        imports_path = ensure_path(imports_file)
+        if imports_path.exists():
+            write_imports = False
+
+    if write_imports and import_dirs:
+        imports = [
+            wdl
+            for path in import_dirs
+            for wdl in glob.glob(str(path / "*.wdl"))
+        ]
+        if imports:
+            if imports_path:
+                ensure_path(imports_path, is_file=True, create=True)
+            else:
+                imports_path = Path(tempfile.mkstemp(suffix=".zip")[1])
+
+            imports_str = " ".join(imports)
+
+            LOG.info(f"Writing imports {imports_str} to zip file {imports_path}")
+            exe = delegator.run(
+                f"zip -j - {imports_str} > {imports_path}", block=True
+            )
+            if not exe.ok:
+                raise Exception(
+                    f"Error creating imports zip file; stdout={exe.out}; "
+                    f"stderr={exe.err}"
+                )
+
+    return imports_path

--- a/pytest_wdl/executors/cromwell.py
+++ b/pytest_wdl/executors/cromwell.py
@@ -1,0 +1,194 @@
+import json
+import os
+from pathlib import Path
+import re
+from typing import List, Optional, Union
+
+import delegator
+
+from pytest_wdl.executors import get_workflow, get_workflow_inputs, get_workflow_imports
+from pytest_wdl.core import Executor, DataFile
+from pytest_wdl.utils import LOG, ensure_path, find_executable_path, find_in_classpath
+
+
+ENV_JAVA_HOME = "JAVA_HOME"
+ENV_CROMWELL_JAR = "CROMWELL_JAR"
+ENV_CROMWELL_CONFIG = "CROMWELL_CONFIG"
+ENV_CROMWELL_ARGS = "CROMWELL_ARGS"
+UNSAFE_RE = re.compile(r"[^\w.-]")
+
+
+class CromwellExecutor(Executor):
+    """
+    Manages the running of WDL workflows using Cromwell.
+
+    Args:
+        project_root: The root path to which non-absolute WDL script paths are
+            relative.
+        import_dirs: Relative or absolute paths to directories containing WDL
+            scripts that should be available as imports.
+        java_bin: Path to the java executable.
+        java_args: Default Java arguments to use; can be overidden by passing
+            `java_args=...` to `run_workflow`.
+        cromwell_jar_file: Path to the Cromwell JAR file.
+        cromwell_args: Default Cromwell arguments to use; can be overridden by
+            passing `cromwell_args=...` to `run_workflow`.
+    """
+    def __init__(
+        self,
+        project_root: Path,
+        import_dirs: Optional[List[Path]] = None,
+        java_bin: Optional[Union[str, Path]] = None,
+        java_args: Optional[str] = None,
+        cromwell_jar_file: Optional[Union[str, Path]] = None,
+        cromwell_config_file: Optional[Union[str, Path]] = None,
+        cromwell_args: Optional[str] = None
+    ):
+        self.project_root = project_root
+        self.import_dirs = import_dirs
+
+        if not java_bin:
+            java_home = os.environ.get(ENV_JAVA_HOME)
+            if java_home:
+                java_bin = Path(java_home) / "bin" / "java"
+            else:
+                java_bin = find_executable_path("java")
+
+        if not java_bin:
+            raise FileNotFoundError("Could not find java executable")
+
+        self.java_bin = ensure_path(
+            java_bin, exists=True, is_file=True, executable=True
+        )
+
+        if not cromwell_jar_file:
+            cromwell_jar = os.environ.get(ENV_CROMWELL_JAR)
+            if cromwell_jar:
+                cromwell_jar_file = ensure_path(cromwell_jar)
+            else:
+                cromwell_jar_file = find_in_classpath("cromwell*.jar")
+
+        if not cromwell_jar_file:
+            raise FileNotFoundError("Could not find Cromwell JAR file")
+
+        self.cromwell_jar_file = ensure_path(
+            cromwell_jar_file, is_file=True, exists=True
+        )
+
+        if not cromwell_config_file:
+            config_file = os.environ.get(ENV_CROMWELL_CONFIG)
+            if config_file:
+                cromwell_config_file = ensure_path(config_file)
+        if cromwell_config_file:
+            self.cromwell_config_file = ensure_path(
+                cromwell_config_file, is_file=True, exists=True
+            )
+        else:
+            self.cromwell_config_file = None
+
+        if not java_args and self.cromwell_config_file:
+            java_args = f"-Dconfig.file={self.cromwell_config_file}"
+        self.java_args = java_args
+
+        self.cromwell_args = cromwell_args or os.environ.get(ENV_CROMWELL_ARGS)
+
+    def run_workflow(
+        self,
+        wdl_script: Union[str, Path],
+        workflow_name: Optional[str] = None,
+        inputs: Optional[dict] = None,
+        expected: Optional[dict] = None,
+        **kwargs
+    ) -> dict:
+        """
+        Run a WDL workflow on given inputs, and check that the output matches
+        given expected values.
+
+        Args:
+            wdl_script: The WDL script to execute.
+            workflow_name: The name of the workflow in the WDL script. If None, the
+                name of the WDL script is used (without the .wdl extension).
+            inputs: Object that will be serialized to JSON and provided to Cromwell
+                as the workflow inputs.
+            expected: Dict mapping output parameter names to expected values.
+            kwargs: Additional keyword arguments, mostly for debugging:
+                * execution_dir: DEPRECATED
+                * inputs_file: Path to the Cromwell inputs file to use. Inputs are
+                    written to this file only if it doesn't exist.
+                * imports_file: Path to the WDL imports file to use. Imports are
+                    written to this file only if it doesn't exist.
+                * java_args: Additional arguments to pass to Java runtime.
+                * cromwell_args: Additional arguments to pass to `cromwell run`.
+
+        Returns:
+            Dict of outputs.
+
+        Raises:
+            Exception: if there was an error executing Cromwell
+            AssertionError: if the actual outputs don't match the expected outputs
+        """
+        if "execution_dir" in kwargs:
+            LOG.warning(
+                f"Parameter execution_dir is deprecated and will be removed. Use "
+                f"the `chdir` context manager instead."
+            )
+            os.chdir(kwargs["execution_dir"])
+
+        wdl_path, workflow_name = get_workflow(
+            self.project_root, wdl_script, workflow_name,
+        )
+
+        inputs_dict, inputs_file = get_workflow_inputs(
+            workflow_name, inputs, kwargs.get("inputs_file")
+        )
+
+        imports_file = get_workflow_imports(
+            self.import_dirs, kwargs.get("imports_file")
+        )
+
+        inputs_arg = f"-i {inputs_file}" if inputs_dict else ""
+        imports_zip_arg = f"-p {imports_file}" if imports_file else ""
+        java_args = kwargs.get("java_args", self.java_args) or ""
+        cromwell_args = kwargs.get("cromwell_args", self.cromwell_args) or ""
+
+        cmd = (
+            f"{self.java_bin} {java_args} -jar {self.cromwell_jar_file} run "
+            f"{cromwell_args} {inputs_arg} {imports_zip_arg} {wdl_path}"
+        )
+        LOG.info(
+            f"Executing cromwell command '{cmd}' with inputs "
+            f"{json.dumps(inputs_dict, default=str)}"
+        )
+        exe = delegator.run(cmd, block=True)
+        if not exe.ok:
+            raise Exception(
+                f"Cromwell command failed; stdout={exe.out}; stderr={exe.err}"
+            )
+
+        outputs = CromwellExecutor.get_cromwell_outputs(exe.out)
+
+        if expected:
+            for name, expected_value in expected.items():
+                key = f"{workflow_name}.{name}"
+                if key not in outputs:
+                    raise AssertionError(f"Workflow did not generate output {key}")
+                if isinstance(expected_value, DataFile):
+                    expected_value.assert_contents_equal(outputs[key])
+                else:
+                    assert expected_value == outputs[key]
+
+        return outputs
+
+    @staticmethod
+    def get_cromwell_outputs(output):
+        lines = output.splitlines(keepends=False)
+        start = None
+        for i, line in enumerate(lines):
+            if line == "{" and lines[i+1].lstrip().startswith('"outputs":'):
+                start = i
+            elif line == "}" and start is not None:
+                end = i
+                break
+        else:
+            raise AssertionError("No outputs JSON found in Cromwell stdout")
+        return json.loads("\n".join(lines[start:(end + 1)]))["outputs"]

--- a/pytest_wdl/executors/cromwell.py
+++ b/pytest_wdl/executors/cromwell.py
@@ -112,7 +112,6 @@ class CromwellExecutor(Executor):
                 as the workflow inputs.
             expected: Dict mapping output parameter names to expected values.
             kwargs: Additional keyword arguments, mostly for debugging:
-                * execution_dir: DEPRECATED
                 * inputs_file: Path to the Cromwell inputs file to use. Inputs are
                     written to this file only if it doesn't exist.
                 * imports_file: Path to the WDL imports file to use. Imports are
@@ -127,13 +126,6 @@ class CromwellExecutor(Executor):
             Exception: if there was an error executing Cromwell
             AssertionError: if the actual outputs don't match the expected outputs
         """
-        if "execution_dir" in kwargs:
-            LOG.warning(
-                f"Parameter execution_dir is deprecated and will be removed. Use "
-                f"the `chdir` context manager instead."
-            )
-            os.chdir(kwargs["execution_dir"])
-
         wdl_path, workflow_name = get_workflow(
             self.project_root, wdl_script, workflow_name,
         )

--- a/pytest_wdl/fixtures.py
+++ b/pytest_wdl/fixtures.py
@@ -18,8 +18,8 @@ from pytest_wdl.core import (
 from pytest_wdl.utils import ensure_path, context_dir, find_project_path
 
 
-ENV_user_config = "PYTEST_user_config"
-DEFAULT_user_config_FILE = "pytest_user_config.json"
+ENV_USER_CONFIG = "PYTEST_WDL_CONFIG"
+DEFAULT_USER_CONFIG_FILE = "pytest_wdl_config.json"
 DEFAULT_TEST_DATA_FILE = "test_data.json"
 DEFAULT_IMPORT_PATHS_FILE = "import_paths.txt"
 
@@ -32,12 +32,12 @@ def user_config_file() -> Optional[Path]:
     Returns:
         Path to the confif file, or None if not specified.
     """
-    config_file = os.environ.get(ENV_user_config)
+    config_file = os.environ.get(ENV_USER_CONFIG)
     config_path = None
     if config_file:
         config_path = ensure_path(config_file)
     else:
-        default_config_path = Path.home() / DEFAULT_user_config_FILE
+        default_config_path = Path.home() / DEFAULT_USER_CONFIG_FILE
         if default_config_path.exists():
             config_path = default_config_path
     if config_path and not config_path.exists():

--- a/pytest_wdl/fixtures.py
+++ b/pytest_wdl/fixtures.py
@@ -13,31 +13,31 @@ from typing import List, Optional, Union
 from _pytest.fixtures import FixtureRequest
 
 from pytest_wdl.core import (
-    EXECUTORS, DataResolver, DataManager, DataDirs, Executor, WdlConfig
+    EXECUTORS, DataResolver, DataManager, DataDirs, Executor, UserConfiguration
 )
 from pytest_wdl.utils import ensure_path, context_dir, find_project_path
 
 
-ENV_WDL_CONFIG = "PYTEST_WDL_CONFIG"
-DEFAULT_WDL_CONFIG_FILE = "pytest_wdl_config.json"
+ENV_user_config = "PYTEST_user_config"
+DEFAULT_user_config_FILE = "pytest_user_config.json"
 DEFAULT_TEST_DATA_FILE = "test_data.json"
 DEFAULT_IMPORT_PATHS_FILE = "import_paths.txt"
 
 
-def wdl_config_file() -> Optional[Path]:
+def user_config_file() -> Optional[Path]:
     """
-    Fixture that provides the value of 'WDL_CONFIG' environment variable. If
-    not specified, looks in the default location ($HOME/pytest_wdl_config.json).
+    Fixture that provides the value of 'user_config' environment variable. If
+    not specified, looks in the default location ($HOME/pytest_user_config.json).
 
     Returns:
         Path to the confif file, or None if not specified.
     """
-    config_file = os.environ.get(ENV_WDL_CONFIG)
+    config_file = os.environ.get(ENV_user_config)
     config_path = None
     if config_file:
         config_path = ensure_path(config_file)
     else:
-        default_config_path = Path.home() / DEFAULT_WDL_CONFIG_FILE
+        default_config_path = Path.home() / DEFAULT_user_config_FILE
         if default_config_path.exists():
             config_path = default_config_path
     if config_path and not config_path.exists():
@@ -45,8 +45,8 @@ def wdl_config_file() -> Optional[Path]:
     return config_path
 
 
-def wdl_config(wdl_config_file: Optional[Path]) -> WdlConfig:
-    config = WdlConfig(wdl_config_file)
+def user_config(user_config_file: Optional[Path]) -> UserConfiguration:
+    config = UserConfiguration(user_config_file)
     yield config
     config.cleanup()
 
@@ -108,16 +108,16 @@ def workflow_data_descriptors(workflow_data_descriptor_file: Union[str, Path]) -
 
 def workflow_data_resolver(
     workflow_data_descriptors: dict,
-    wdl_config: WdlConfig
+    user_config: UserConfiguration
 ) -> DataResolver:
     """
     Provides access to test data files for tests in a module.
 
     Args:
         workflow_data_descriptors: workflow_data_descriptors fixture.
-        wdl_config:
+        user_config:
     """
-    return DataResolver(workflow_data_descriptors, wdl_config)
+    return DataResolver(workflow_data_descriptors, user_config)
 
 
 def workflow_data(
@@ -196,7 +196,7 @@ def import_dirs(
 def cromwell_executor(
     project_root: Union[str, Path],
     import_dirs: List[Union[str, Path]],
-    wdl_config: WdlConfig
+    user_config: UserConfiguration
 ) -> Executor:
     """
     Provides a harness for calling Cromwell on WDL scripts.
@@ -204,7 +204,7 @@ def cromwell_executor(
     Args:
         project_root: Project root directory.
         import_dirs: Directories from which to import WDL scripts.
-        wdl_config:
+        user_config:
 
     Examples:
         def test_workflow(cromwell_executor):
@@ -216,11 +216,11 @@ def cromwell_executor(
     return executor_class(
         project_root=project_root,
         import_dirs=import_dirs,
-        **wdl_config.get_executor_defaults("cromwell")
+        **user_config.get_executor_defaults("cromwell")
     )
 
 
-def workflow_runner(cromwell_executor: Executor, wdl_config: WdlConfig):
+def workflow_runner(cromwell_executor: Executor, user_config: UserConfiguration):
     """
     Provides a callable that runs a workflow (with the same signature as
     `CromwellHarness.run_workflow`) with the execution directory being the
@@ -233,7 +233,7 @@ def workflow_runner(cromwell_executor: Executor, wdl_config: WdlConfig):
         expected: Optional[dict] = None,
         **kwargs
     ):
-        with context_dir(wdl_config.default_execution_dir, change_dir=True):
+        with context_dir(user_config.default_execution_dir, change_dir=True):
             cromwell_executor.run_workflow(
                 wdl_script, workflow_name, inputs, expected, **kwargs
             )

--- a/pytest_wdl/utils.py
+++ b/pytest_wdl/utils.py
@@ -13,7 +13,7 @@ import shutil
 import stat
 import tempfile
 from typing import Dict, Generic, Optional, Sequence, Type, TypeVar, Union, cast
-from urllib import request
+from urllib import request, parse
 
 from pkg_resources import EntryPoint, iter_entry_points
 from py._path.local import LocalPath
@@ -453,6 +453,10 @@ def download_file(
         for name, value in http_headers.items():
             req.add_header(name, value)
     if proxies:
+        # TODO: Should we only set the proxy associated with the URL scheme?
+        #  Should we raise an exception if there is not a proxy defined for
+        #  the URL scheme?
+        # parsed = parse.urlparse(url)
         for proxy_type, url in proxies.items():
             req.set_proxy(url, proxy_type)
     rsp = request.urlopen(req)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+coverage
+delegator.py
+pysam
+pytest

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,12 @@ setup(
         "pytest11": [
             "pytest_wdl = pytest_wdl"
         ],
-        "pytest_wdl": [
+        "pytest_wdl.data_types": [
             "bam = pytest_wdl.data_types.bam:BamDataFile",
             "vcf = pytest_wdl.data_types.vcf:VcfDataFile",
+        ],
+        "pytest_wdl.executors": [
+            "cromwell = pytest_wdl.executors.cromwell:CromwellExecutorFactory"
         ]
     },
     py_modules=["pytest_wdl"],

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,18 @@ import codecs
 import os
 from setuptools import setup, find_packages
 
+
+extras_require = {
+    "bam": ["pysam"],
+    "progress": ["tqdm"]
+}
+extras_require["all"] = [
+    lib
+    for lib_array in extras_require.values()
+    for lib in lib_array
+]
+
+
 setup(
     name="pytest-wdl",
     use_scm_version=True,
@@ -33,8 +45,5 @@ setup(
         "pytest",
         "delegator.py"
     ],
-    extras_require={
-        "all": ["pysam"],
-        "bam": ["pysam"]
-    }
+    extras_require=extras_require
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
             "vcf = pytest_wdl.data_types.vcf:VcfDataFile",
         ],
         "pytest_wdl.executors": [
-            "cromwell = pytest_wdl.executors.cromwell:CromwellExecutorFactory"
+            "cromwell = pytest_wdl.executors.cromwell:CromwellExecutor"
         ]
     },
     py_modules=["pytest_wdl"],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,10 +24,10 @@ def setenv(envvars: dict):
             if v is None:
                 os.environ.pop(k)
             else:
-                os.environ[k] = v
+                os.environ[k] = str(v)
         elif v is not None:
             to_remove.append(k)
-            os.environ[k] = v
+            os.environ[k] = str(v)
     try:
         yield
     finally:

--- a/tests/test_bam/test_bam.py
+++ b/tests/test_bam/test_bam.py
@@ -21,8 +21,8 @@ def workflow_data_descriptor_file(project_root):
 @pytest.mark.skipif(no_internet, reason="no internet available")
 def test_bam(workflow_data, workflow_runner):
     workflow_runner(
-        wdl_script='tests/test_bam/test_bam.wdl',
-        workflow_name='test_bam',
+        wdl_script="tests/test_bam/test_bam.wdl",
+        workflow_name="test_bam",
         inputs={"bam": workflow_data["bam"]},
         expected={"output_bam": workflow_data["output_bam"]}
     )
@@ -32,8 +32,8 @@ def test_bam_removing_randomness(workflow_data, workflow_runner):
     """Test that BAMs with the only difference being random IDs
     added by samtools are evaluated as equal."""
     workflow_runner(
-        wdl_script='tests/test_bam/test_bam_norandom.wdl',
-        workflow_name='test_bam_no_random',
+        wdl_script="tests/test_bam/test_bam_norandom.wdl",
+        workflow_name="test_bam_no_random",
         inputs={
             "bam": workflow_data["random_id_bam_input"]
         },

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -67,13 +67,13 @@ def test_user_config_from_file():
             "http": "http://foo.com/http",
             "https": "http://foo.com/https"
         }
-        assert config.default_http_headers == {
-            re.compile("http://foo.com/.*"): {
-                "pattern": "http://foo.com/.*",
+        assert config.default_http_headers == [
+            {
+                "pattern": re.compile("http://foo.com/.*"),
                 "name": "foo",
                 "env": "FOO_HEADER"
             }
-        }
+        ]
         assert config.get_executor_defaults("foo") == {"bar": 1}
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -163,18 +163,20 @@ def test_url_localizer_add_headers():
     }):
         localizer = UrlLocalizer(
             "http://foo.com/bork",
-            UserConfiguration(http_headers={
-                re.compile(r"http://foo.com/.*"): {
+            UserConfiguration(http_headers=[
+                {
                     "name": "beep",
+                    "pattern": re.compile(r"http://foo.com/.*"),
                     "env": "FOO",
                     "value": "baz"
                 },
-                re.compile(r"http://foo.*/bork"): {
+                {
                     "name": "boop",
+                    "pattern": re.compile(r"http://foo.*/bork"),
                     "env": "BAR",
                     "value": "blorf"
                 }
-            }),
+            ]),
             {
                 "boop": {
                     "value": "blammo"

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -1,0 +1,197 @@
+import json
+from pathlib import Path
+import zipfile
+from pytest_wdl.utils import tempdir
+import pytest
+
+from pytest_wdl.utils import ENV_PATH, ENV_CLASSPATH
+from pytest_wdl.executors import get_workflow, get_workflow_imports, get_workflow_inputs
+from pytest_wdl.executors.cromwell import (
+    ENV_CROMWELL_CONFIG, ENV_JAVA_HOME, ENV_CROMWELL_ARGS, ENV_CROMWELL_JAR,
+    CromwellExecutor
+)
+from . import setenv, make_executable
+
+
+def test_java_bin():
+    with tempdir() as d:
+        java = d / "bin" / "java"
+        java.parent.mkdir(parents=True)
+        with open(java, "wt") as out:
+            out.write("foo")
+        make_executable(java)
+
+        with setenv({ENV_JAVA_HOME: str(d)}):
+            assert CromwellExecutor(d).java_bin == java
+
+        with setenv({
+            ENV_PATH: str(d / "bin"),
+            ENV_JAVA_HOME: None
+        }):
+            assert CromwellExecutor(d).java_bin == java
+
+        with setenv({
+            ENV_PATH: None,
+            ENV_JAVA_HOME: None
+        }):
+            with pytest.raises(FileNotFoundError):
+                assert CromwellExecutor(d).java_bin
+
+    with setenv({ENV_JAVA_HOME: "foo"}):
+        with pytest.raises(FileNotFoundError):
+            assert CromwellExecutor(d).java_bin
+
+
+def test_cromwell_config():
+    with tempdir() as d:
+        assert CromwellExecutor(d).cromwell_config_file is None
+        config = d / "config"
+        with setenv({ENV_CROMWELL_CONFIG: str(config)}):
+            with pytest.raises(FileNotFoundError):
+                CromwellExecutor(d)
+            with open(config, "wt") as out:
+                out.write("foo")
+            assert CromwellExecutor(d).cromwell_config_file == config
+
+
+def test_java_args():
+    with tempdir() as d:
+        assert CromwellExecutor(d).java_args is None
+
+        with pytest.raises(FileNotFoundError):
+            CromwellExecutor(d, cromwell_config_file=Path("foo")).java_args
+
+        config = d / "config"
+        with pytest.raises(FileNotFoundError):
+            CromwellExecutor(d, cromwell_config_file=Path("foo")).java_args
+        with open(config, "wt") as out:
+            out.write("foo")
+        assert CromwellExecutor(
+            d, cromwell_config_file=config
+        ).java_args == f"-Dconfig.file={config}"
+
+
+def test_cromwell_jar():
+    with tempdir() as d:
+        jar = d / "cromwell.jar"
+
+        with setenv({ENV_CROMWELL_JAR: str(jar)}):
+            with pytest.raises(FileNotFoundError):
+                CromwellExecutor(d).cromwell_jar_file
+            with open(jar, "wt") as out:
+                out.write("foo")
+            assert CromwellExecutor(d).cromwell_jar_file == jar
+
+        with setenv({
+            ENV_CROMWELL_JAR: None,
+            ENV_CLASSPATH: str(d)
+        }):
+            assert CromwellExecutor(d).cromwell_jar_file == jar
+
+        with setenv({
+            ENV_CROMWELL_JAR: None,
+            ENV_CLASSPATH: str(jar)
+        }):
+            assert CromwellExecutor(d).cromwell_jar_file == jar
+
+        with setenv({
+            ENV_CROMWELL_JAR: None,
+            ENV_CLASSPATH: None
+        }):
+            with pytest.raises(FileNotFoundError):
+                CromwellExecutor(d).cromwell_jar_file
+
+
+def test_get_workflow():
+    with tempdir() as d:
+        wdl = d / "test.wdl"
+        with pytest.raises(FileNotFoundError):
+            get_workflow(d, "test.wdl")
+        with open(wdl, "wt") as out:
+            out.write("workflow test {}")
+        assert get_workflow(d, "test.wdl") == (wdl, "test")
+        assert get_workflow(d, "test.wdl", "foo") == (wdl, "foo")
+
+
+def test_get_workflow_inputs():
+    actual_inputs_dict, inputs_path = get_workflow_inputs("foo", {"bar": 1})
+    assert inputs_path.exists()
+    with open(inputs_path, "rt") as inp:
+        assert json.load(inp) == actual_inputs_dict
+    assert actual_inputs_dict == {
+        "foo.bar": 1
+    }
+
+    with tempdir() as d:
+        inputs_file = d / "inputs.json"
+        actual_inputs_dict, inputs_path = get_workflow_inputs(
+            "foo", {"bar": 1}, inputs_file
+        )
+        assert inputs_file == inputs_path
+        assert inputs_path.exists()
+        with open(inputs_path, "rt") as inp:
+            assert json.load(inp) == actual_inputs_dict
+        assert actual_inputs_dict == {
+            "foo.bar": 1
+        }
+
+    with tempdir() as d:
+        inputs_file = d / "inputs.json"
+        inputs_dict = {"foo.bar": 1}
+        with open(inputs_file, "wt") as out:
+            json.dump(inputs_dict, out)
+        actual_inputs_dict, inputs_path = get_workflow_inputs(
+            "foo", inputs_file=inputs_file
+        )
+        assert inputs_file == inputs_path
+        assert inputs_path.exists()
+        with open(inputs_path, "rt") as inp:
+            assert json.load(inp) == actual_inputs_dict
+        assert actual_inputs_dict == inputs_dict
+
+
+def test_get_workflow_imports():
+    with tempdir() as d:
+        wdl_dir = d / "foo"
+        wdl = wdl_dir / "bar.wdl"
+        wdl_dir.mkdir()
+        with open(wdl, "wt") as out:
+            out.write("foo")
+        zip_path = get_workflow_imports([wdl_dir])
+        assert zip_path.exists()
+        with zipfile.ZipFile(zip_path, "r") as import_zip:
+            names = import_zip.namelist()
+            assert len(names) == 1
+            assert names[0] == "bar.wdl"
+            with import_zip.open("bar.wdl", "r") as inp:
+                assert inp.read().decode() == "foo"
+
+    with tempdir() as d:
+        wdl_dir = d / "foo"
+        wdl = wdl_dir / "bar.wdl"
+        wdl_dir.mkdir()
+        with open(wdl, "wt") as out:
+            out.write("foo")
+        imports_file = d / "imports.zip"
+        zip_path = get_workflow_imports([wdl_dir], imports_file)
+        assert zip_path.exists()
+        assert zip_path == imports_file
+        with zipfile.ZipFile(zip_path, "r") as import_zip:
+            names = import_zip.namelist()
+            assert len(names) == 1
+            assert names[0] == "bar.wdl"
+            with import_zip.open("bar.wdl", "r") as inp:
+                assert inp.read().decode() == "foo"
+
+    with tempdir() as d:
+        wdl_dir = d / "foo"
+        wdl = wdl_dir / "bar.wdl"
+        wdl_dir.mkdir()
+        with open(wdl, "wt") as out:
+            out.write("foo")
+        imports_file = d / "imports.zip"
+        with open(imports_file, "wt") as out:
+            out.write("foo")
+        zip_path = get_workflow_imports(imports_file=imports_file)
+        assert zip_path.exists()
+        assert zip_path == imports_file

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from pytest_wdl.fixtures import (
-    ENV_user_config, DEFAULT_user_config_FILE, import_dirs, user_config_file
+    ENV_USER_CONFIG, DEFAULT_USER_CONFIG_FILE, import_dirs, user_config_file
 )
 from pytest_wdl.utils import tempdir
 import pytest
@@ -10,7 +10,7 @@ from . import setenv
 def test_user_config_file():
     with tempdir() as d:
         config = d / "config.json"
-        with setenv({ENV_user_config: config}):
+        with setenv({ENV_USER_CONFIG: config}):
             with pytest.raises(FileNotFoundError):
                 user_config_file()
             with open(config, "wt") as out:
@@ -18,7 +18,7 @@ def test_user_config_file():
             assert user_config_file() == config
 
     with tempdir() as d, setenv({"HOME": str(d)}):
-        config = d / DEFAULT_user_config_FILE
+        config = d / DEFAULT_USER_CONFIG_FILE
         with open(config, "wt") as out:
             out.write("foo")
         assert user_config_file() == config

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,27 +1,27 @@
 from pathlib import Path
 from pytest_wdl.fixtures import (
-    ENV_WDL_CONFIG, DEFAULT_WDL_CONFIG_FILE, import_dirs, wdl_config_file
+    ENV_user_config, DEFAULT_user_config_FILE, import_dirs, user_config_file
 )
 from pytest_wdl.utils import tempdir
 import pytest
 from . import setenv
 
 
-def test_wdl_config_file():
+def test_user_config_file():
     with tempdir() as d:
         config = d / "config.json"
-        with setenv({ENV_WDL_CONFIG: config}):
+        with setenv({ENV_user_config: config}):
             with pytest.raises(FileNotFoundError):
-                wdl_config_file()
+                user_config_file()
             with open(config, "wt") as out:
                 out.write("foo")
-            assert wdl_config_file() == config
+            assert user_config_file() == config
 
     with tempdir() as d, setenv({"HOME": str(d)}):
-        config = d / DEFAULT_WDL_CONFIG_FILE
+        config = d / DEFAULT_user_config_FILE
         with open(config, "wt") as out:
             out.write("foo")
-        assert wdl_config_file() == config
+        assert user_config_file() == config
 
 
 def test_fixtures(workflow_data, workflow_runner):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,8 +1,27 @@
 from pathlib import Path
-from pytest_wdl.fixtures import import_dirs
+from pytest_wdl.fixtures import (
+    ENV_WDL_CONFIG, DEFAULT_WDL_CONFIG_FILE, import_dirs, wdl_config_file
+)
 from pytest_wdl.utils import tempdir
 import pytest
-from unittest.mock import Mock
+from . import setenv
+
+
+def test_wdl_config_file():
+    with tempdir() as d:
+        config = d / "config.json"
+        with setenv({ENV_WDL_CONFIG: config}):
+            with pytest.raises(FileNotFoundError):
+                wdl_config_file()
+            with open(config, "wt") as out:
+                out.write("foo")
+            assert wdl_config_file() == config
+
+    with tempdir() as d, setenv({"HOME": str(d)}):
+        config = d / DEFAULT_WDL_CONFIG_FILE
+        with open(config, "wt") as out:
+            out.write("foo")
+        assert wdl_config_file() == config
 
 
 def test_fixtures(workflow_data, workflow_runner):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,11 +1,8 @@
 from pathlib import Path
-from pytest_wdl.fixtures import (
-    import_dirs, java_bin, cromwell_config_file, java_args, cromwell_jar_file
-)
+from pytest_wdl.fixtures import import_dirs
 from pytest_wdl.utils import tempdir
 import pytest
 from unittest.mock import Mock
-from . import setenv, make_executable
 
 
 def test_fixtures(workflow_data, workflow_runner):
@@ -22,109 +19,16 @@ def test_fixtures(workflow_data, workflow_runner):
 
 def test_import_dirs():
     with pytest.raises(FileNotFoundError):
-        import_dirs(None, Path.cwd(), "foo")
+        import_dirs(Path.cwd(), "foo")
 
     with tempdir() as d:
         foo = d / "foo"
         with open(foo, "wt") as out:
             out.write("bar")
         with pytest.raises(FileNotFoundError):
-            import_dirs(None, d, foo)
+            import_dirs(d, foo)
 
     with tempdir(change_dir=True) as cwd:
         tests = cwd / "tests"
         tests.mkdir()
-        req = Mock()
-        req.fspath.dirpath.return_value = str(tests)
-
-        assert import_dirs(req, None, None) == []
-
-        foo = cwd / "foo.wdl"
-        with open(foo, "wt") as out:
-            out.write("foo")
-        assert import_dirs(req, None, None) == [cwd]
-
-
-def test_java_bin():
-    with tempdir() as d:
-        java = d / "bin" / "java"
-        java.parent.mkdir(parents=True)
-        with open(java, "wt") as out:
-            out.write("foo")
-        make_executable(java)
-
-        with setenv({"JAVA_HOME": str(d)}):
-            assert java_bin() == java
-
-        with setenv({
-            "PATH": str(d / "bin"),
-            "JAVA_HOME": None
-        }):
-            assert java_bin() == java
-
-        with setenv({
-            "PATH": None,
-            "JAVA_HOME": None
-        }):
-            with pytest.raises(FileNotFoundError):
-                java_bin()
-
-    with setenv({"JAVA_HOME": "foo"}):
-        with pytest.raises(FileNotFoundError):
-            java_bin()
-
-
-def test_cromwell_config():
-    assert cromwell_config_file() is None
-    with tempdir() as d:
-        config = d / "config"
-        with setenv({"CROMWELL_CONFIG_FILE": str(config)}):
-            with pytest.raises(FileNotFoundError):
-                cromwell_config_file()
-            with open(config, "wt") as out:
-                out.write("foo")
-            assert cromwell_config_file() == config
-
-
-def test_java_args():
-    assert java_args(None) is None
-    with pytest.raises(FileNotFoundError):
-        java_args(Path("foo"))
-    with tempdir() as d:
-        config = d / "config"
-        with pytest.raises(FileNotFoundError):
-            java_args(config)
-        with open(config, "wt") as out:
-            out.write("foo")
-        assert java_args(config) == f"-Dconfig.file={config}"
-
-
-def test_cromwell_jar():
-    with tempdir() as d:
-        jar = d / "cromwell.jar"
-
-        with setenv({"CROMWELL_JAR": str(jar)}):
-            with pytest.raises(FileNotFoundError):
-                cromwell_jar_file()
-            with open(jar, "wt") as out:
-                out.write("foo")
-            assert cromwell_jar_file() == jar
-
-        with setenv({
-            "CROMWELL_JAR": None,
-            "CLASSPATH": str(d)
-        }):
-            assert cromwell_jar_file() == jar
-
-        with setenv({
-            "CROMWELL_JAR": None,
-            "CLASSPATH": str(jar)
-        }):
-            assert cromwell_jar_file() == jar
-
-        with setenv({
-            "CROMWELL_JAR": None,
-            "CLASSPATH": None
-        }):
-            with pytest.raises(FileNotFoundError):
-                cromwell_jar_file()
+        assert import_dirs(None, None) == []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from pytest_wdl.utils import (
-    tempdir, chdir, env_dir as _test_dir, to_path, resolve_file,
+    tempdir, chdir, context_dir, to_path, resolve_file,
     find_executable_path, find_project_path, env_map
 )
 from . import setenv, make_executable
@@ -28,18 +28,16 @@ def test_cd():
     assert Path.cwd() == curdir
 
 
-def test_test_dir():
+def test_context_dir():
     with tempdir() as d1:
-        os.environ.setdefault("FOO", str(d1))
-
-        with _test_dir("FOO") as d2:
+        with context_dir(d1 / "foo") as d2:
             foo = d2 / "foo"
             with open(foo, "wt") as out:
                 out.write("foo")
 
         assert foo.exists()
 
-        with _test_dir("BAR") as d3:
+        with context_dir() as d3:
             bar = d3 / "bar"
             with open(bar, "wt") as out:
                 out.write("bar")
@@ -48,9 +46,11 @@ def test_test_dir():
 
         d4 = d1 / "blorf"
         assert not d4.exists()
-        os.environ.setdefault("BLORF", str(d4))
-        with _test_dir("BLORF"):
+        with context_dir(d4):
             assert d4.exists()
+        with context_dir(d4, cleanup=True):
+            pass
+        assert not d4.exists()
 
     assert not foo.exists()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from pytest_wdl.utils import (
-    tempdir, chdir, context_dir, to_path, resolve_file,
+    tempdir, chdir, context_dir, ensure_path, resolve_file,
     find_executable_path, find_project_path, env_map
 )
 from . import setenv, make_executable
@@ -57,10 +57,10 @@ def test_context_dir():
 
 def test_to_path():
     cwd = Path.cwd()
-    assert to_path(cwd) == cwd
+    assert ensure_path(cwd) == cwd
     cwd_str = str(cwd)
-    assert to_path(cwd_str) == cwd
-    assert to_path(cwd.name, cwd.parent) == cwd
+    assert ensure_path(cwd_str) == cwd
+    assert ensure_path(cwd.name, cwd.parent) == cwd
 
 
 def test_resolve_file():


### PR DESCRIPTION
This refactoring incorporates the changes in #32 and also does the following:

* Eliminates proxy-related fixtures
* Creates a new executors package with a cromwell module, and makes executors pluggable
* Puts all the user-specific configuration (proxies, default http headers, executor options, cache and execution dir) in a WdlConfig class that can load values from a config file and/or environment variables.

Still to do:
* Tests for http headers and proxies in UrlLocalizer
* Update documentation