### PR TITLE
Enable miniwdl tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=[
         "pytest>=5.1",
         "subby>=0.1.6",
-        "miniwdl>=0.3.0",
+        "miniwdl>=0.4.1",
         "pytest-subtests",
         "xphyle>=4.1.2"
     ],

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -17,12 +17,13 @@ import json
 import pytest
 
 from pytest_wdl.utils import tempdir
-from pytest_wdl.core import DefaultDataFile, create_executor
+from pytest_wdl.core import EXECUTORS, DefaultDataFile, create_executor
 from pytest_wdl.executors import get_workflow_inputs, make_serializable
 
 
 @pytest.mark.integration
-def test_executors(workflow_data, workflow_runner):
+@pytest.mark.parametrize("executor", EXECUTORS.keys())
+def test_executors(workflow_data, workflow_runner, executor):
     inputs = {
         "in_txt": workflow_data["in_txt"],
         "in_int": 1
@@ -35,14 +36,15 @@ def test_executors(workflow_data, workflow_runner):
         "test.wdl",
         inputs,
         outputs,
-        executors=["cromwell"] #list(EXECUTORS.keys())
+        executors=[executor]
     )
     # Test with the old workflow_runner signature
     workflow_runner(
         "test.wdl",
         "cat_file",
         inputs,
-        outputs
+        outputs,
+        executors=[executor]
     )
 
 


### PR DESCRIPTION
It appears that miniwdl tests work now. I am not sure if this is something we fixed in pytest-wdl or something that was fixed in miniwdl. Please test to make sure it works on your machine as well.