### PR TITLE
Add a new exception type for execution failures

### DIFF
--- a/pytest_wdl/executors/__init__.py
+++ b/pytest_wdl/executors/__init__.py
@@ -15,12 +15,69 @@ from abc import ABCMeta, abstractmethod
 import json
 from pathlib import Path
 import tempfile
+import textwrap
 from typing import List, Optional, Sequence, Tuple
 
 from pytest_wdl.data_types import DataFile
 from pytest_wdl.utils import ensure_path, safe_string
 
 from WDL import Tree
+
+
+INDENT = " " * 16
+
+
+class ExecutionFailedError(Exception):
+    def __init__(
+        self,
+        executor: str,
+        target: str,
+        status: str,
+        inputs: Optional[dict] = None,
+        executor_stdout: Optional[str] = None,
+        executor_stderr: Optional[str] = None,
+        failed_task: Optional[str] = None,
+        failed_task_stdout: Optional[str] = None,
+        failed_task_stderr: Optional[str] = None,
+        msg: Optional[str] = None
+    ):
+        if msg is None:
+            if failed_task and failed_task != target:
+                msg = f"{executor} failed with status {status} while running task " \
+                      f"{failed_task} of {target}"
+            else:
+                msg = f"{executor} failed with status {status} while running {target}"
+        super().__init__(msg)
+        self.executor = executor
+        self.target = target
+        self.status = status
+        self.inputs = inputs
+        self.executor_stdout = executor_stdout
+        self.executor_stderr = executor_stderr
+        self.failed_task = failed_task
+        self.failed_task_stdout = failed_task_stdout
+        self.failed_task_stderr = failed_task_stderr
+
+    def __str__(self):
+        def wrap_std(std: str):
+            if std:
+                return textwrap.indent(std, INDENT).lstrip()
+            else:
+                return "None"
+
+        return textwrap.dedent(f"""
+        {self.args[0]}:
+            inputs:
+                {self.inputs}
+            executor_stdout:
+                {wrap_std(self.executor_stdout)}
+            executor_stderr:
+                {wrap_std(self.executor_stderr)}
+            failed_task_stdout:
+                {wrap_std(self.failed_task_stdout)}
+            failed_task_stderr:
+                {wrap_std(self.failed_task_stderr)}
+        """)
 
 
 class Executor(metaclass=ABCMeta):
@@ -73,7 +130,7 @@ class Executor(metaclass=ABCMeta):
             Dict of outputs.
 
         Raises:
-            Exception: if there was an error executing the workflow
+            ExecutionFailedError: if there was an error executing the workflow
             AssertionError: if the actual outputs don't match the expected outputs
         """
 

--- a/pytest_wdl/executors/__init__.py
+++ b/pytest_wdl/executors/__init__.py
@@ -37,6 +37,7 @@ class ExecutionFailedError(Exception):
         executor_stdout: Optional[str] = None,
         executor_stderr: Optional[str] = None,
         failed_task: Optional[str] = None,
+        failed_task_exit_status: Optional[int] = None,
         failed_task_stdout: Optional[str] = None,
         failed_task_stderr: Optional[str] = None,
         msg: Optional[str] = None
@@ -55,28 +56,33 @@ class ExecutionFailedError(Exception):
         self.executor_stdout = executor_stdout
         self.executor_stderr = executor_stderr
         self.failed_task = failed_task
+        self.failed_task_exit_status = failed_task_exit_status
         self.failed_task_stdout = failed_task_stdout
         self.failed_task_stderr = failed_task_stderr
+
+    @property
+    def exit_status_str(self) -> str:
+        if self.failed_task_exit_status:
+            return str(self.failed_task_exit_status)
+        else:
+            return "Unknown"
 
     def __str__(self):
         def wrap_std(std: str):
             if std:
-                return textwrap.indent(std, INDENT).lstrip()
+                return "\n" + textwrap.indent(std, INDENT)
             else:
-                return "None"
+                return " None"
 
         return textwrap.dedent(f"""
         {self.args[0]}:
             inputs:
                 {self.inputs}
-            executor_stdout:
-                {wrap_std(self.executor_stdout)}
-            executor_stderr:
-                {wrap_std(self.executor_stderr)}
-            failed_task_stdout:
-                {wrap_std(self.failed_task_stdout)}
-            failed_task_stderr:
-                {wrap_std(self.failed_task_stderr)}
+            executor_stdout:{wrap_std(self.executor_stdout)}
+            executor_stderr:{wrap_std(self.executor_stderr)}
+            failed_task_exit_status: {self.exit_status_str}
+            failed_task_stdout:{wrap_std(self.failed_task_stdout)}
+            failed_task_stderr:{wrap_std(self.failed_task_stderr)}
         """)
 
 

--- a/pytest_wdl/executors/cromwell.py
+++ b/pytest_wdl/executors/cromwell.py
@@ -185,9 +185,10 @@ class CromwellExecutor(Executor):
                     ))
                     if failed:
                         failed_task = call_name
+                        failed_call = failed[0]
                         failed_task_stdout, failed_task_stderr = (
                             CromwellExecutor.read_cromwell_task_std(path)
-                            for path in (metadata["stdout"], metadata["stderr"])
+                            for path in (failed_call["stdout"], failed_call["stderr"])
                         )
 
                         num_failed = len(failed)
@@ -284,13 +285,14 @@ class CromwellExecutor(Executor):
         return imports_path
 
     @staticmethod
-    def read_cromwell_task_std(path: Path) -> Optional[str]:
-        if not path.exists():
-            path = path.with_suffix(".background")
-        if not path.exists():
-            return None
-        with open(path, "rt") as inp:
-            return inp.read()
+    def read_cromwell_task_std(path: str) -> Optional[str]:
+        if path:
+            p = Path(path)
+            if not p.exists():
+                p = p.with_suffix(".background")
+            if p.exists():
+                with open(p, "rt") as inp:
+                    return inp.read()
 
     @staticmethod
     def get_cromwell_outputs(output) -> dict:

--- a/pytest_wdl/executors/cromwell.py
+++ b/pytest_wdl/executors/cromwell.py
@@ -175,6 +175,7 @@ class CromwellExecutor(Executor):
             else:
                 status = metadata["status"]
                 failed_task = None
+                failed_task_exit_status = None
                 failed_task_stdout = None
                 failed_task_stderr = None
                 msg = None
@@ -186,6 +187,7 @@ class CromwellExecutor(Executor):
                     if failed:
                         failed_task = call_name
                         failed_call = failed[0]
+                        failed_task_exit_status = failed_call["returnCode"]
                         failed_task_stdout, failed_task_stderr = (
                             CromwellExecutor.read_cromwell_task_std(path)
                             for path in (failed_call["stdout"], failed_call["stderr"])
@@ -209,6 +211,7 @@ class CromwellExecutor(Executor):
                     executor_stdout=exe.output,
                     executor_stderr=exe.error,
                     failed_task=failed_task,
+                    failed_task_exit_status=failed_task_exit_status,
                     failed_task_stdout=failed_task_stdout,
                     failed_task_stderr=failed_task_stderr,
                     msg=msg

--- a/pytest_wdl/executors/miniwdl.py
+++ b/pytest_wdl/executors/miniwdl.py
@@ -105,12 +105,12 @@ class MiniwdlExecutor(Executor):
                 #max_workers=max_workers,
             )
         except Error.EvalError as err:  # TODO: test errors
-            log_source(logger, err)
+            MiniwdlExecutor.log_source(logger, err)
             raise
         except Error.RuntimeError as err:
             cause = err.__cause__ or err
             if isinstance(getattr(cause, "pos", None), Error.SourcePosition):
-                log_source(logger, cause)
+                MiniwdlExecutor.log_source(logger, cause)
             if isinstance(err, runtime.error.TaskFailure):
                 failed_task_exit_status = None
                 failed_task_stderr = None
@@ -149,17 +149,15 @@ class MiniwdlExecutor(Executor):
                 with open(path, "rt") as inp:
                     return inp.read()
 
-        return None
-
-
-def log_source(logger: logging.Logger, exn: Exception):
-    pos = cast(Error.SourcePosition, getattr(exn, "pos"))
-    logger.error(
-        "({} Ln {} Col {}) {}{}".format(
-            pos.uri,
-            pos.line,
-            pos.column,
-            exn.__class__.__name__,
-            (", " + str(exn) if str(exn) else ""),
+    @staticmethod
+    def log_source(logger: logging.Logger, exn: Exception):
+        pos = cast(Error.SourcePosition, getattr(exn, "pos"))
+        logger.error(
+            "({} Ln {} Col {}) {}{}".format(
+                pos.uri,
+                pos.line,
+                pos.column,
+                exn.__class__.__name__,
+                (", " + str(exn) if str(exn) else ""),
+            )
         )
-    )

--- a/pytest_wdl/fixtures.py
+++ b/pytest_wdl/fixtures.py
@@ -288,8 +288,8 @@ def workflow_runner(
         if not executors:
             executors = default_executors
 
-        def _run_test(executor_name):
-            executor = create_executor(executor_name, import_dir_paths, user_config)
+        def _run_test(_executor_name):
+            executor = create_executor(_executor_name, import_dir_paths, user_config)
             with context_dir(user_config.default_execution_dir, change_dir=True):
                 executor.run_workflow(
                     wdl_path,

--- a/tests/submodule/submodule.wdl
+++ b/tests/submodule/submodule.wdl
@@ -9,3 +9,16 @@ task foo {
     File out = "output"
   }
 }
+
+task foo_fail {
+  String s
+
+  command <<<
+  echo -e ${s} > output
+  exit 1
+  >>>
+
+  output {
+    File out = "output"
+  }
+}

--- a/tests/test.wdl
+++ b/tests/test.wdl
@@ -19,19 +19,32 @@ task cat {
 workflow cat_file {
   File in_txt
   Int in_int
+  Boolean? fail
+
+  Boolean default_fail = select_first([fail, false])
 
   call cat {
     input: in_txt = in_txt
   }
 
-  call submodule.foo {
-    input:
-      s = "foo"
+  if (default_fail) {
+    call submodule.foo_fail {
+      input:
+        s = "foo"
+    }
   }
+  if (!default_fail) {
+    call submodule.foo {
+      input:
+        s = "foo"
+    }
+  }
+
+  File foo_out = select_first([foo_fail.out, foo.out])
 
   output {
     File out_txt = cat.out_txt
-    File out2 = foo.out
+    File out2 = foo_out
     Int out_int = in_int
   }
 }

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import json
+from typing import cast
 
 import pytest
 
@@ -118,13 +119,17 @@ def test_execution_failure(workflow_data, workflow_runner, executor):
         "out_txt": workflow_data["out_txt"],
         "out_int": 1
     }
-    with pytest.raises(ExecutionFailedError):
+    with pytest.raises(ExecutionFailedError) as exc_info:
         workflow_runner(
             "test.wdl",
             inputs,
             outputs,
             executors=[executor]
         )
+
+    err = cast(ExecutionFailedError, exc_info.value)
+    assert "foo_fail" in err.failed_task
+    assert err.failed_task_exit_status == 1
 
 
 def test_get_workflow_inputs():

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -16,13 +16,11 @@ import json
 
 import pytest
 
-from pytest_wdl.config import ENV_DEFAULT_EXECUTORS
 from pytest_wdl.core import EXECUTORS, DefaultDataFile, create_executor
 from pytest_wdl.executors import (
-    get_workflow_inputs, make_serializable, validate_outputs
+    ExecutionFailedError, get_workflow_inputs, make_serializable, validate_outputs
 )
 from pytest_wdl.utils import tempdir
-from . import setenv
 
 
 @pytest.mark.integration
@@ -106,6 +104,27 @@ def test_task(workflow_data, workflow_runner, executor):
         executors=[executor],
         task_name="cat"
     )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("executor", EXECUTORS.keys())
+def test_execution_failure(workflow_data, workflow_runner, executor):
+    inputs = {
+        "in_txt": workflow_data["in_txt"],
+        "in_int": 1,
+        "fail": True
+    }
+    outputs = {
+        "out_txt": workflow_data["out_txt"],
+        "out_int": 1
+    }
+    with pytest.raises(ExecutionFailedError):
+        workflow_runner(
+            "test.wdl",
+            inputs,
+            outputs,
+            executors=[executor]
+        )
 
 
 def test_get_workflow_inputs():


### PR DESCRIPTION
When the execution fails, raise a custom exception that includes lots of context. Most importantly, the error message includes the stderr from the failed task.

In addition, this addresses #69 by using the -m argument with cromwell to write the metadata to a JSON file, and preferentially reads the success/failure information from that file.