### PR TITLE
Support subworkflows in Cromwell Metadata

### DIFF
--- a/pytest_wdl/__init__.py
+++ b/pytest_wdl/__init__.py
@@ -18,6 +18,8 @@ purposes, the implementaiton of these fixtures is done in the pytest_wdl.fixture
 module.
 """
 from pytest_wdl import fixtures
+from pytest_wdl.executors import ExecutionFailedError
+
 import pytest
 
 

--- a/pytest_wdl/core.py
+++ b/pytest_wdl/core.py
@@ -101,23 +101,27 @@ class DataResolver:
         self.user_config = user_config
 
     def resolve(self, name: str, datadirs: Optional[DataDirs] = None):
-        if name not in self.data_descriptors:
-            raise ValueError(f"Unrecognized name {name}")
+        if name in self.data_descriptors:
+            value = self.data_descriptors[name]
 
-        value = self.data_descriptors[name]
-
-        if isinstance(value, dict):
-            # Right now, "class" is just a marker for object types, of which
-            # "file" is a special case.
-            cls = value.get("class", "file")
-            if "value" in value:
-                value = value["value"]
-            if cls == "file":
-                return create_data_file(
-                    user_config=self.user_config,
-                    datadirs=datadirs,
-                    **cast(dict, value)
-                )
+            if isinstance(value, dict):
+                # Right now, "class" is just a marker for object types, of which
+                # "file" is a special case.
+                cls = value.get("class", "file")
+                if "value" in value:
+                    value = value["value"]
+                if cls == "file":
+                    value = create_data_file(
+                        user_config=self.user_config,
+                        datadirs=datadirs,
+                        **cast(dict, value)
+                    )
+        else:
+            value = create_data_file(
+                name=name,
+                user_config=self.user_config,
+                datadirs=datadirs
+            )
 
         return value
 

--- a/pytest_wdl/data_types/__init__.py
+++ b/pytest_wdl/data_types/__init__.py
@@ -53,7 +53,12 @@ class DataFile(metaclass=ABCMeta):
 
     @property
     def path(self) -> Path:
-        if not self.local_path.exists():
+        if not (self.local_path.exists() or self.localizer):
+            raise RuntimeError(
+                f"Localization to {self.local_path} is required but no localizer is "
+                f"defined"
+            )
+        if self.localizer and not self.localizer.verify(self.local_path):
             self.localizer.localize(self.local_path)
         return self.local_path
 

--- a/pytest_wdl/data_types/__init__.py
+++ b/pytest_wdl/data_types/__init__.py
@@ -53,13 +53,14 @@ class DataFile(metaclass=ABCMeta):
 
     @property
     def path(self) -> Path:
-        if not (self.local_path.exists() or self.localizer):
-            raise RuntimeError(
-                f"Localization to {self.local_path} is required but no localizer is "
-                f"defined"
-            )
-        if self.localizer and not self.localizer.verify(self.local_path):
-            self.localizer.localize(self.local_path)
+        if not self.local_path.exists():
+            if self.localizer:
+                self.localizer.localize(self.local_path)
+            else:
+                raise RuntimeError(
+                    f"Localization to {self.local_path} is required but no localizer "
+                    f"is defined"
+                )
         return self.local_path
 
     def __str__(self) -> str:

--- a/pytest_wdl/localizers.py
+++ b/pytest_wdl/localizers.py
@@ -21,7 +21,9 @@ from xphyle import open_
 
 from pytest_wdl.config import UserConfiguration
 from pytest_wdl.url_schemes import Response, ResponseWrapper
-from pytest_wdl.utils import LOG, env_map, resolve_value_descriptor
+from pytest_wdl.utils import (
+    LOG, DigestsNotEqualError, env_map, resolve_value_descriptor, verify_digests
+)
 
 
 class Localizer(metaclass=ABCMeta):  # pragma: no-cover
@@ -37,6 +39,17 @@ class Localizer(metaclass=ABCMeta):  # pragma: no-cover
             destination: Path to file where the non-local resource is to be localized.
         """
         pass
+
+    def verify(self, path: Path) -> bool:
+        """Verify that `path` exists and is valid.
+
+        Args:
+            path: Path to verify.
+
+        Returns:
+            True if the path is verified, else False
+        """
+        return path.exists()
 
 
 class UrlLocalizer(Localizer):
@@ -54,6 +67,17 @@ class UrlLocalizer(Localizer):
         self.user_config = user_config
         self._http_headers = http_headers
         self.digests = digests
+
+    def verify(self, path: Path) -> bool:
+        if not super().verify(path):
+            return False
+        if self.digests:
+            try:
+                verify_digests(path, self.digests)
+            except DigestsNotEqualError:
+                path.unlink()
+                return False
+        return True
 
     def localize(self, destination: Path):
         try:

--- a/pytest_wdl/localizers.py
+++ b/pytest_wdl/localizers.py
@@ -75,6 +75,11 @@ class UrlLocalizer(Localizer):
             try:
                 verify_digests(path, self.digests)
             except DigestsNotEqualError:
+                LOG.exception(
+                    "%s already exists but its digest does not match the expected "
+                    "digest; deleting the existing file and re-downloading from "
+                    "%s", str(path), self.url
+                )
                 path.unlink()
                 return False
         return True

--- a/pytest_wdl/url_schemes/__init__.py
+++ b/pytest_wdl/url_schemes/__init__.py
@@ -21,7 +21,7 @@ from urllib.request import BaseHandler, Request, build_opener, install_opener
 
 from pkg_resources import iter_entry_points
 
-from pytest_wdl.utils import LOG, PluginFactory, DigestsNotEqualError, hash_file
+from pytest_wdl.utils import LOG, PluginFactory, verify_digests
 
 try:
     from tqdm import tqdm as progress
@@ -124,20 +124,7 @@ class BaseResponse(Response, metaclass=ABCMeta):
             )
 
         if digests:
-            for hash_name, expected_digest in digests.items():
-                try:
-                    actual_digest = hash_file(destination, hash_name)
-                except AssertionError:  # TODO: test this
-                    LOG.warning(
-                        "Hash algorithm %s is not supported; cannot verify file %s",
-                        hash_name, destination
-                    )
-                    continue
-                if actual_digest != expected_digest:
-                    raise DigestsNotEqualError(
-                        f"{hash_name} digest {actual_digest} of downloaded file"
-                        f" {destination} does match expected value {expected_digest}"
-                    )
+            verify_digests(destination, digests)
 
 
 class ResponseWrapper(BaseResponse):

--- a/pytest_wdl/utils.py
+++ b/pytest_wdl/utils.py
@@ -509,3 +509,20 @@ def hash_file(path: Path, hash_name: str = "md5") -> str:
         hashobj = hashlib.new(hash_name)
         hashobj.update(inp.read())
         return hashobj.hexdigest()
+
+
+def verify_digests(path: Path, digests: dict):
+    for hash_name, expected_digest in digests.items():
+        try:
+            actual_digest = hash_file(path, hash_name)
+        except AssertionError:  # TODO: test this
+            LOG.warning(
+                "Hash algorithm %s is not supported; cannot verify file %s",
+                hash_name, path
+            )
+            continue
+        if actual_digest != expected_digest:
+            raise DigestsNotEqualError(
+                f"{hash_name} digest {actual_digest} of file "
+                f"{path} does match expected value {expected_digest}"
+            )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -191,7 +191,7 @@ def test_data_resolver():
         fun.__name__ = "test_foo"
         dd = DataDirs(d, mod, fun)
         resolver = DataResolver(test_data, UserConfiguration(None, cache_dir=d))
-        with pytest.raises(ValueError):
+        with pytest.raises(FileNotFoundError):
             resolver.resolve("bork", dd)
         assert resolver.resolve("foo", dd).path == foo_txt
         assert resolver.resolve("bar", dd) == 1

--- a/tests/test_cromwell.py
+++ b/tests/test_cromwell.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import json
 from pathlib import Path
 import zipfile
 
@@ -20,7 +21,7 @@ import pytest
 
 from pytest_wdl.utils import ENV_PATH, ENV_CLASSPATH
 from pytest_wdl.executors.cromwell import (
-    ENV_CROMWELL_CONFIG, ENV_JAVA_HOME, ENV_CROMWELL_JAR, CromwellExecutor
+    ENV_CROMWELL_CONFIG, ENV_JAVA_HOME, ENV_CROMWELL_JAR, CromwellExecutor, Failures
 )
 from . import setenv, make_executable
 
@@ -162,3 +163,25 @@ def test_get_workflow_imports():
         zip_path = executor.get_workflow_imports(imports_file=imports_file)
         assert zip_path.exists()
         assert zip_path == imports_file
+
+
+def test_failure_metadata(workflow_data):
+    m44 = workflow_data["metadata44.json"]
+    with open(m44.path, "rt") as inp:
+        m44_dict = json.load(inp)
+    failures = CromwellExecutor.get_failures(m44_dict)
+    assert failures.num_failed == 10
+    assert failures.failed_task == "contam_testing_set_org_by_volume.org_blast"
+    assert failures.failed_task_exit_status == "Unknown"
+    assert "6717f340-b948-4e97-ac2c-bdba793893f5" in failures._failed_task_stdout_path
+    assert "6717f340-b948-4e97-ac2c-bdba793893f5" in failures._failed_task_stderr_path
+
+    m47 = workflow_data["metadata47.json"]
+    with open(m47.path, "rt") as inp:
+        m47_dict = json.load(inp)
+    failures = CromwellExecutor.get_failures(m47_dict)
+    assert failures.num_failed == 10
+    assert failures.failed_task == "contam_testing_set_org_by_volume.org_blast"
+    assert failures.failed_task_exit_status == "Unknown"
+    assert "563012ef-e593-42dc-9de0-f0a682ce23e3" in failures._failed_task_stdout_path
+    assert "563012ef-e593-42dc-9de0-f0a682ce23e3" in failures._failed_task_stderr_path

--- a/tests/test_cromwell/metadata44.json
+++ b/tests/test_cromwell/metadata44.json
@@ -1,0 +1,5546 @@
+{
+  "workflowProcessingEvents": [{
+    "cromwellId": "cromid-8696c00",
+    "description": "PickedUp",
+    "timestamp": "2019-10-14T14:51:33.876Z",
+    "cromwellVersion": "44"
+  }, {
+    "cromwellId": "cromid-8696c00",
+    "description": "Finished",
+    "timestamp": "2019-10-14T14:53:11.471Z",
+    "cromwellVersion": "44"
+  }],
+  "actualWorkflowLanguageVersion": "Biscayne",
+  "submittedFiles": {
+    "workflow": "version development\n\nimport \"contam_testing.wdl\" as contam_testing\n\ntask sort {\n\n  input {\n    File input_file String output_file\n  }\n\n   command <<<\n     sort ~{input_file} > ~{output_file}\n   >>>\n\n   runtime {\n     docker: \"debian:stretch-slim\"\n   }\n\n   output {\n     File sorted_output = \"${output_file}\"\n   }\n\n}\n\nworkflow test_contam_testing {\n\n  input {\n        Map[String, Map[String, Pair[Array[File], File]]] samples\n        Array[OrgBlastDB]+ org_blast_databases\n        Array[IDBlastDB] id_blast_databases\n        File taxon_names_cdb\n        File taxon_paths_cdb # AKA cdb_index_mapping_taxon_ids_to_paths\n        String output_prefix\n        Boolean? create_homopolymer_report\n        Float? suppress_reads_homopolymer_cutoff\n        Boolean? use_total_retrieval_sequences\n        Int read_name_format\n        Int? number_of_reads\n        Int? number_of_sets\n        String? fq_fa_or_bam\n  }\n\n  call contam_testing.contam_testing {\n    input:\n        samples = samples,\n        org_blast_databases = org_blast_databases,\n        id_blast_databases = id_blast_databases,\n        taxon_names_cdb = taxon_names_cdb,\n        taxon_paths_cdb = taxon_paths_cdb,\n        output_prefix = output_prefix,\n        create_homopolymer_report = create_homopolymer_report,\n        suppress_reads_homopolymer_cutoff = suppress_reads_homopolymer_cutoff,\n        use_total_retrieval_sequences = use_total_retrieval_sequences,\n        read_name_format = read_name_format,\n        number_of_reads = number_of_reads,\n        number_of_sets = number_of_sets,\n        fq_fa_or_bam = fq_fa_or_bam\n  }\n\n  call sort {\n    input:\n      input_file=contam_testing.final_org_hit_based_reports[1],\n      output_file=\"sorted_final_org_hit_based_reports\"\n  }\n\n  output {\n    Array[File] org_hit_based = [sort.sorted_output]\n    Array[File] org_read_details = contam_testing.final_org_read_details_reports\n    Array[File] org_read_based = contam_testing.final_org_read_based_reports\n  }\n\n}",
+    "root": "",
+    "options": "{\n\n}",
+    "inputs": "{\"test_contam_testing.id_blast_databases\": [{\"blast_database_volumes\": [\"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\"], \"database_name\": \"vector\", \"evalue\": \"1e-15\", \"filter\": \"1\", \"friendly_names\": [[\"2\", \"Eubacteria\"], [\"2157\", \"Archaea\"], [\"4751\", \"Fungi\"], [\"6231\", \"Nematodes\"], [\"6447\", \"Molusks\"], [\"6656\", \"Arthropods\"], [\"9263\", \"Marsupials\"], [\"9443\", \"Primates\"], [\"9539\", \"Macaques\"], [\"9541\", \"Cyno (M. fascicularis)\"], [\"9606\", \"Human\"], [\"9989\", \"Rodents\"], [\"10029\", \"CHO\"], [\"10090\", \"Mouse\"], [\"10116\", \"Rat\"], [\"10239\", \"Viruses\"], [\"33090\", \"Green Plants\"], [\"33208\", \"Animals\"], [\"40674\", \"Mammals\"], [\"50557\", \"Insects\"], [\"314295\", \"Apes\"]], \"min_match_identity_pct\": \"95\", \"min_match_length_bp\": \"25\", \"target_taxon_id\": \"9606\"}, {\"blast_database_volumes\": [\"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\"], \"database_name\": \"ngs_adaptor\", \"evalue\": \"1e-12\", \"filter\": \"0\", \"friendly_names\": [[\"2\", \"Eubacteria\"], [\"2157\", \"Archaea\"], [\"4751\", \"Fungi\"], [\"6231\", \"Nematodes\"], [\"6447\", \"Molusks\"], [\"6656\", \"Arthropods\"], [\"9263\", \"Marsupials\"], [\"9443\", \"Primates\"], [\"9539\", \"Macaques\"], [\"9541\", \"Cyno (M. fascicularis)\"], [\"9606\", \"Human\"], [\"9989\", \"Rodents\"], [\"10029\", \"CHO\"], [\"10090\", \"Mouse\"], [\"10116\", \"Rat\"], [\"10239\", \"Viruses\"], [\"33090\", \"Green Plants\"], [\"33208\", \"Animals\"], [\"40674\", \"Mammals\"], [\"50557\", \"Insects\"], [\"314295\", \"Apes\"]], \"min_match_identity_pct\": \"99\", \"min_match_length_bp\": \"35\", \"target_taxon_id\": \"9606\"}], \"test_contam_testing.number_of_reads\": \"100000\", \"test_contam_testing.number_of_sets\": \"10\", \"test_contam_testing.org_blast_databases\": [{\"blast_database_volumes\": [\"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\"], \"database_name\": \"standard_org\", \"db_index_cdb\": \"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb\", \"evalue\": \"1e-8\", \"filter\": \"1\", \"friendly_names\": [[\"2\", \"Eubacteria\"], [\"2157\", \"Archaea\"], [\"4751\", \"Fungi\"], [\"6231\", \"Nematodes\"], [\"6447\", \"Molusks\"], [\"6656\", \"Arthropods\"], [\"9263\", \"Marsupials\"], [\"9443\", \"Primates\"], [\"9539\", \"Macaques\"], [\"9541\", \"Cyno (M. fascicularis)\"], [\"9606\", \"Human\"], [\"9989\", \"Rodents\"], [\"10029\", \"CHO\"], [\"10090\", \"Mouse\"], [\"10116\", \"Rat\"], [\"10239\", \"Viruses\"], [\"33090\", \"Green Plants\"], [\"33208\", \"Animals\"], [\"40674\", \"Mammals\"], [\"50557\", \"Insects\"], [\"314295\", \"Apes\"]], \"max_informative_taxa_hits\": \"5\", \"minimum_taxa_hits\": \"2\", \"number_of_hits\": \"10\", \"reconcile_lca_or_random\": \"lca\", \"summary_taxon\": [[\"2\", \"Eubacteria\"], [\"2157\", \"Archaea\"], [\"4751\", \"Fungi\"], [\"9443\", \"Primates\"], [\"9989\", \"Rodents\"], [\"10239\", \"Viruses\"], [\"33090\", \"Green Plants\"], [\"33208\", \"Animals\"], [\"40674\", \"Mammals\"], [\"314295\", \"Apes\"]], \"target_taxon_id\": \"9606\"}], \"test_contam_testing.output_prefix\": \"20190604164608\", \"test_contam_testing.read_name_format\": \"0\", \"test_contam_testing.taxon_names_cdb\": \"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/term_data.cdb\", \"test_contam_testing.taxon_paths_cdb\": \"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb\", \"test_contam_testing.fq_fa_or_bam\": \"fq\", \"test_contam_testing.samples\": {\"C836.BICR_18.2.chr22\": {\"C836.BICR_18.2.chr22.Assay\": {\"left\": [\"/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz\"], \"right\": \"/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz\"}}}}",
+    "workflowUrl": "/Users/c252930/omics/contam/tests/test_contam_testing.wdl",
+    "labels": "{}"
+  },
+  "calls": {
+    "test_contam_testing.contam_testing": [{
+      "retryableFailure": false,
+      "executionStatus": "Failed",
+      "subWorkflowMetadata": {
+        "workflowName": "contam_testing",
+        "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+        "calls": {
+          "contam_testing.contam_testing_sample": [{
+            "retryableFailure": false,
+            "executionStatus": "Failed",
+            "subWorkflowMetadata": {
+              "workflowName": "contam_testing_sample",
+              "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+              "calls": {
+                "contam_testing_sample.fetch": [{
+                  "executionStatus": "Done",
+                  "subWorkflowMetadata": {
+                    "workflowName": "fetch",
+                    "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                    "calls": {
+                      "multi_lane_fetch.fastq_fetch": [{
+                        "executionStatus": "Done",
+                        "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/stdout",
+                        "backendStatus": "Done",
+                        "commandLine": "set -ex\n\nfq_fetch \\\n  -o C836.BICR_18.2.chr22.fq.gz \\\n  -n 100000 \\\n  -m 10  \\\n  -R 0 \\\n   \\\n   -F 0 \\\n   \\\n   \\\n   -S 0.0 \\\n  /cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/inputs/1995001600/C836.BICR_18.2.chr22.fq.gz\n\n# rename stats output so it doesn't get globbed with read sets.\nmv C836.BICR_18.2.chr22.fq.gz.stats C836.BICR_18.2.chr22.fq.gz_stats.stats",
+                        "shardIndex": 0,
+                        "outputs": {
+                          "homopolymer_report": [],
+                          "read_details_report": [],
+                          "stats_output": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/C836.BICR_18.2.chr22.fq.gz_stats.stats",
+                          "fq_read_sets": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                        },
+                        "runtimeAttributes": {
+                          "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/fq_fetch:0.1.0",
+                          "failOnStderr": "false",
+                          "maxRetries": "0",
+                          "continueOnReturnCode": "0"
+                        },
+                        "callCaching": {
+                          "allowResultReuse": false,
+                          "effectiveCallCachingMode": "CallCachingOff"
+                        },
+                        "inputs": {
+                          "read_summary_format": 0,
+                          "output_prefix": null,
+                          "suppress_reads_homopolymer_cutoff_defined": 0.0,
+                          "default_prefix": "C836.BICR_18.2.chr22.fq.gz",
+                          "output_read_details_report_defined": "",
+                          "default_number_of_sets": 10,
+                          "number_of_sets": 10,
+                          "default_read_name_multiply_for_homopolymer": false,
+                          "suppress_reads_homopolymer_cutoff": 0.0,
+                          "default_read_summary_format": 0,
+                          "is_fasta": false,
+                          "output_homopolymer_report_defined": "C836.BICR_18.2.chr22.fq.gz.homopolymer_report.txt",
+                          "number_of_reads": 100000,
+                          "default_number_of_reads": 100000,
+                          "read_name_multiply_for_homopolymer": false,
+                          "fastq": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                          "output_read_details_report": null,
+                          "output_homopolymer_report": null
+                        },
+                        "returnCode": 0,
+                        "jobId": "84336",
+                        "backend": "Local",
+                        "end": "2019-10-14T14:51:58.789Z",
+                        "dockerImageUsed": "elilillyco-omics-docker-lc.jfrog.io/qc/fq_fetch:0.1.0",
+                        "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/stderr",
+                        "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0",
+                        "attempt": 1,
+                        "executionEvents": [{
+                          "startTime": "2019-10-14T14:51:54.111Z",
+                          "description": "RequestingExecutionToken",
+                          "endTime": "2019-10-14T14:51:54.808Z"
+                        }, {
+                          "startTime": "2019-10-14T14:51:54.808Z",
+                          "description": "WaitingForValueStore",
+                          "endTime": "2019-10-14T14:51:54.813Z"
+                        }, {
+                          "startTime": "2019-10-14T14:51:54.813Z",
+                          "description": "PreparingJob",
+                          "endTime": "2019-10-14T14:51:54.875Z"
+                        }, {
+                          "startTime": "2019-10-14T14:51:58.788Z",
+                          "description": "UpdatingJobStore",
+                          "endTime": "2019-10-14T14:51:58.790Z"
+                        }, {
+                          "startTime": "2019-10-14T14:51:54.875Z",
+                          "description": "RunningJob",
+                          "endTime": "2019-10-14T14:51:58.788Z"
+                        }, {
+                          "startTime": "2019-10-14T14:51:54.101Z",
+                          "description": "Pending",
+                          "endTime": "2019-10-14T14:51:54.111Z"
+                        }],
+                        "start": "2019-10-14T14:51:54.091Z"
+                      }]
+                    },
+                    "outputs": {
+                      "multi_lane_fetch.read_sets": [["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                      "multi_lane_fetch.read_details_report": [[]],
+                      "multi_lane_fetch.homopolymer_report": [[]],
+                      "multi_lane_fetch.stats_output": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/C836.BICR_18.2.chr22.fq.gz_stats.stats"]
+                    },
+                    "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                    "id": "a13f3f8a-955e-416e-b330-45dd5ca45d37",
+                    "inputs": {
+                      "multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+                      "read_summary_format": 0,
+                      "multi_lane_fetch.bam_fetch.output_read_details_report": null,
+                      "multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+                      "input_files": {
+                        "right": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                        "left": ["/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz"]
+                      },
+                      "multi_lane_fetch.fastq_fetch.output_prefix": null,
+                      "create_homopolymer_report": false,
+                      "number_of_sets": 10,
+                      "multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+                      "multi_lane_fetch.fasta_fetch.output_read_details_report": null,
+                      "multi_lane_fetch.bam_fetch.output_prefix": null,
+                      "suppress_reads_homopolymer_cutoff": 0.0,
+                      "multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+                      "number_of_reads": 100000,
+                      "multi_lane_fetch.fasta_fetch.output_prefix": null,
+                      "fq_fa_or_bam": "fq"
+                    },
+                    "status": "Succeeded",
+                    "parentWorkflowId": "44d7d360-b648-41c2-98c0-d24d9b2f10bd",
+                    "end": "2019-10-14T14:52:03.282Z",
+                    "start": "2019-10-14T14:51:47.921Z"
+                  },
+                  "shardIndex": 0,
+                  "outputs": {
+                    "read_sets": [["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                    "read_details_report": [[]],
+                    "homopolymer_report": [[]],
+                    "stats_output": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/C836.BICR_18.2.chr22.fq.gz_stats.stats"]
+                  },
+                  "inputs": {
+                    "multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+                    "read_summary_format": 0,
+                    "multi_lane_fetch.bam_fetch.output_read_details_report": null,
+                    "multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+                    "input_files": {
+                      "right": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                      "left": ["/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz"]
+                    },
+                    "multi_lane_fetch.fastq_fetch.output_prefix": null,
+                    "create_homopolymer_report": false,
+                    "number_of_sets": 10,
+                    "multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+                    "multi_lane_fetch.fasta_fetch.output_read_details_report": null,
+                    "multi_lane_fetch.bam_fetch.output_prefix": null,
+                    "suppress_reads_homopolymer_cutoff": 0.0,
+                    "multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+                    "number_of_reads": 100000,
+                    "multi_lane_fetch.fasta_fetch.output_prefix": null,
+                    "fq_fa_or_bam": "fq"
+                  },
+                  "end": "2019-10-14T14:52:03.282Z",
+                  "attempt": 1,
+                  "executionEvents": [{
+                    "startTime": "2019-10-14T14:51:47.920Z",
+                    "description": "WaitingForValueStore",
+                    "endTime": "2019-10-14T14:51:47.921Z"
+                  }, {
+                    "startTime": "2019-10-14T14:51:47.924Z",
+                    "description": "SubWorkflowRunningState",
+                    "endTime": "2019-10-14T14:52:03.282Z"
+                  }, {
+                    "startTime": "2019-10-14T14:51:47.920Z",
+                    "description": "SubWorkflowPendingState",
+                    "endTime": "2019-10-14T14:51:47.920Z"
+                  }, {
+                    "startTime": "2019-10-14T14:51:47.921Z",
+                    "description": "SubWorkflowPreparingState",
+                    "endTime": "2019-10-14T14:51:47.924Z"
+                  }],
+                  "start": "2019-10-14T14:51:47.920Z"
+                }],
+                "contam_testing_sample.contam_testing_assay_org": [{
+                  "retryableFailure": false,
+                  "executionStatus": "Failed",
+                  "subWorkflowMetadata": {
+                    "workflowName": "contam_testing_assay_org",
+                    "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                    "calls": {
+                      "contam_testing_assay_org.contam_testing_set_org": [{
+                        "retryableFailure": false,
+                        "executionStatus": "Failed",
+                        "subWorkflowMetadata": {
+                          "workflowName": "contam_testing_set_org",
+                          "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                          "calls": {
+                            "contam_testing_set_org.contam_testing_set_org_by_volume": [{
+                              "retryableFailure": false,
+                              "executionStatus": "Failed",
+                              "subWorkflowMetadata": {
+                                "workflowName": "contam_testing_set_org_by_volume",
+                                "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                                "calls": {
+                                  "contam_testing_set_org_by_volume.org_blast": [{
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/execution/stdout",
+                                    "shardIndex": 0,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.1.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:55.132Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.808Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:55.132Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:55.132Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.887Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:55.132Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.808Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.887Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.622Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.621Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.622Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.621Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/execution/stdout",
+                                    "shardIndex": 1,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.10.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:00.750Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:53:00.750Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:00.750Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.902Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:00.750Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.620Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.620Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.902Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.620Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.620Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/execution/stdout",
+                                    "shardIndex": 2,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.2.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:57.872Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:57.872Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:57.872Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.809Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.622Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.622Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.622Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.848Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:57.872Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.809Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.848Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.622Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/execution/stdout",
+                                    "shardIndex": 3,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.3.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:57.330Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.623Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:57.330Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:57.330Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.809Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.855Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.855Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:57.330Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.623Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.623Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.809Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.623Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/execution/stdout",
+                                    "shardIndex": 4,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.4.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:01.122Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.905Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:01.122Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:01.122Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.620Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.620Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.620Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.905Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:01.122Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.620Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/execution/stdout",
+                                    "shardIndex": 5,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.5.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:04.560Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.890Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:04.560Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.809Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.890Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.623Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.809Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:04.560Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:04.560Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.623Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.623Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.623Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/execution/stdout",
+                                    "shardIndex": 6,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.6.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:03.641Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.621Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.621Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:03.640Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:03.641Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.808Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.834Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:03.640Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.808Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.834Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.621Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.621Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/execution/stdout",
+                                    "shardIndex": 7,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.7.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:00.121Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.622Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.810Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.837Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.622Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.622Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:00.121Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:00.121Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.810Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.837Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:00.121Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.622Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/execution/stdout",
+                                    "shardIndex": 8,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.8.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:03.351Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.621Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.621Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:03.351Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:03.351Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.810Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.810Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.810Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.842Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.621Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.810Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.842Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:03.351Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.621Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/execution/stdout",
+                                    "shardIndex": 9,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.9.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:04.113Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.876Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:04.113Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.620Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.621Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.807Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.621Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.807Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.876Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:04.113Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:04.113Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.620Z"
+                                  }]
+                                },
+                                "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                                "id": "6717f340-b948-4e97-ac2c-bdba793893f5",
+                                "inputs": {
+                                  "read_summary_format": 0,
+                                  "number_of_hits": 10,
+                                  "reconcile_lca_or_random": "lca",
+                                  "contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                                  "contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                                  "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                                  "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                                  "max_informative_taxa_hits": 5,
+                                  "minimum_taxa_hits": 2,
+                                  "filter": 1,
+                                  "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                  "contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                                  "evalue": "1e-8",
+                                  "target_taxon_id": 9606,
+                                  "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                                },
+                                "status": "Failed",
+                                "parentWorkflowId": "38c2ac67-c3c3-4fa8-996d-995fae040a0f",
+                                "end": "2019-10-14T14:53:05.542Z",
+                                "start": "2019-10-14T14:52:14.463Z"
+                              },
+                              "shardIndex": 0,
+                              "inputs": {
+                                "read_summary_format": 0,
+                                "number_of_hits": 10,
+                                "reconcile_lca_or_random": "lca",
+                                "contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                                "contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                                "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                                "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                                "max_informative_taxa_hits": 5,
+                                "minimum_taxa_hits": 2,
+                                "filter": 1,
+                                "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                "contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                                "evalue": "1e-8",
+                                "target_taxon_id": 9606,
+                                "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                              },
+                              "failures": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                        "causedBy": []
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }],
+                                "message": "Workflow failed"
+                              }],
+                              "end": "2019-10-14T14:53:05.542Z",
+                              "attempt": 1,
+                              "executionEvents": [{
+                                "startTime": "2019-10-14T14:52:14.468Z",
+                                "description": "SubWorkflowRunningState",
+                                "endTime": "2019-10-14T14:53:05.542Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.463Z",
+                                "description": "WaitingForValueStore",
+                                "endTime": "2019-10-14T14:52:14.463Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.463Z",
+                                "description": "SubWorkflowPreparingState",
+                                "endTime": "2019-10-14T14:52:14.468Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.462Z",
+                                "description": "SubWorkflowPendingState",
+                                "endTime": "2019-10-14T14:52:14.463Z"
+                              }],
+                              "start": "2019-10-14T14:52:14.462Z"
+                            }]
+                          },
+                          "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                          "id": "38c2ac67-c3c3-4fa8-996d-995fae040a0f",
+                          "inputs": {
+                            "read_summary_format": 0,
+                            "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                            "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                            "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                            "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                            "org_blast_database": {
+                              "number_of_hits": 10,
+                              "reconcile_lca_or_random": "lca",
+                              "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                              "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                              "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                              "max_informative_taxa_hits": 5,
+                              "minimum_taxa_hits": 2,
+                              "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                              "filter": 1,
+                              "database_name": "standard_org",
+                              "evalue": "1e-8",
+                              "target_taxon_id": 9606,
+                              "reporting_cutoff_percentage": null
+                            },
+                            "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                          },
+                          "status": "Failed",
+                          "parentWorkflowId": "0018baac-191a-45ee-882f-36808a731b8e",
+                          "end": "2019-10-14T14:53:06.480Z",
+                          "start": "2019-10-14T14:52:10.381Z"
+                        },
+                        "shardIndex": 0,
+                        "inputs": {
+                          "read_summary_format": 0,
+                          "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                          "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                          "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                          "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                          "org_blast_database": {
+                            "number_of_hits": 10,
+                            "reconcile_lca_or_random": "lca",
+                            "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                            "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                            "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                            "max_informative_taxa_hits": 5,
+                            "minimum_taxa_hits": 2,
+                            "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                            "filter": 1,
+                            "database_name": "standard_org",
+                            "evalue": "1e-8",
+                            "target_taxon_id": 9606,
+                            "reporting_cutoff_percentage": null
+                          },
+                          "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                        },
+                        "failures": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }],
+                            "message": "Workflow failed"
+                          }],
+                          "message": "Workflow failed"
+                        }],
+                        "end": "2019-10-14T14:53:06.480Z",
+                        "attempt": 1,
+                        "executionEvents": [{
+                          "startTime": "2019-10-14T14:52:10.381Z",
+                          "description": "SubWorkflowPreparingState",
+                          "endTime": "2019-10-14T14:52:10.388Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.388Z",
+                          "description": "SubWorkflowRunningState",
+                          "endTime": "2019-10-14T14:53:06.480Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.380Z",
+                          "description": "SubWorkflowPendingState",
+                          "endTime": "2019-10-14T14:52:10.380Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.380Z",
+                          "description": "WaitingForValueStore",
+                          "endTime": "2019-10-14T14:52:10.381Z"
+                        }],
+                        "start": "2019-10-14T14:52:10.380Z"
+                      }]
+                    },
+                    "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                    "id": "0018baac-191a-45ee-882f-36808a731b8e",
+                    "inputs": {
+                      "read_summary_format": 0,
+                      "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                      "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                      "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                      "read_sets": [["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                      "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                      "org_blast_database": {
+                        "number_of_hits": 10,
+                        "reconcile_lca_or_random": "lca",
+                        "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                        "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                        "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                        "max_informative_taxa_hits": 5,
+                        "minimum_taxa_hits": 2,
+                        "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                        "filter": 1,
+                        "database_name": "standard_org",
+                        "evalue": "1e-8",
+                        "target_taxon_id": 9606,
+                        "reporting_cutoff_percentage": null
+                      },
+                      "sample_name": "C836.BICR_18.2.chr22"
+                    },
+                    "status": "Failed",
+                    "parentWorkflowId": "44d7d360-b648-41c2-98c0-d24d9b2f10bd",
+                    "end": "2019-10-14T14:53:07.500Z",
+                    "start": "2019-10-14T14:52:06.294Z"
+                  },
+                  "shardIndex": 0,
+                  "inputs": {
+                    "read_summary_format": 0,
+                    "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                    "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                    "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                    "read_sets": [["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                    "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                    "org_blast_database": {
+                      "number_of_hits": 10,
+                      "reconcile_lca_or_random": "lca",
+                      "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                      "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                      "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                      "max_informative_taxa_hits": 5,
+                      "minimum_taxa_hits": 2,
+                      "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                      "filter": 1,
+                      "database_name": "standard_org",
+                      "evalue": "1e-8",
+                      "target_taxon_id": 9606,
+                      "reporting_cutoff_percentage": null
+                    },
+                    "sample_name": "C836.BICR_18.2.chr22"
+                  },
+                  "failures": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }],
+                        "message": "Workflow failed"
+                      }],
+                      "message": "Workflow failed"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "end": "2019-10-14T14:53:07.501Z",
+                  "attempt": 1,
+                  "executionEvents": [{
+                    "startTime": "2019-10-14T14:52:06.301Z",
+                    "description": "SubWorkflowRunningState",
+                    "endTime": "2019-10-14T14:53:07.500Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.293Z",
+                    "description": "WaitingForValueStore",
+                    "endTime": "2019-10-14T14:52:06.294Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.294Z",
+                    "description": "SubWorkflowPreparingState",
+                    "endTime": "2019-10-14T14:52:06.301Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.292Z",
+                    "description": "SubWorkflowPendingState",
+                    "endTime": "2019-10-14T14:52:06.293Z"
+                  }],
+                  "start": "2019-10-14T14:52:06.292Z"
+                }],
+                "contam_testing_sample.contam_testing_assay_id": [{
+                  "retryableFailure": false,
+                  "executionStatus": "Failed",
+                  "subWorkflowMetadata": {
+                    "workflowName": "contam_testing_assay_id",
+                    "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                    "calls": {
+                      "contam_testing_assay_id.contam_testing_set_id": [{
+                        "retryableFailure": false,
+                        "executionStatus": "Failed",
+                        "subWorkflowMetadata": {
+                          "workflowName": "contam_testing_set_id",
+                          "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                          "calls": {
+                            "contam_testing_set_id.contam_testing_set_id_by_volume": [{
+                              "retryableFailure": false,
+                              "executionStatus": "Failed",
+                              "subWorkflowMetadata": {
+                                "workflowName": "contam_testing_set_id_by_volume",
+                                "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                                "calls": {
+                                  "contam_testing_set_id_by_volume.id_blast": [{
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/execution/stdout",
+                                    "shardIndex": 0,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.1.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:00.402Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.916Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.916Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:00.402Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:00.402Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:00.402Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.583Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.583Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/execution/stdout",
+                                    "shardIndex": 1,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.10.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:54.903Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.884Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:54.903Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.884Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.583Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:54.903Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:54.903Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.583Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/execution/stdout",
+                                    "shardIndex": 2,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.2.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:03.593Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.582Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.583Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.886Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:03.592Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:03.593Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.886Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:03.592Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.582Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/execution/stdout",
+                                    "shardIndex": 3,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.3.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:57.952Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.585Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:57.952Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:57.952Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.584Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.585Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.845Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:57.952Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.807Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.807Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.845Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.585Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/execution/stdout",
+                                    "shardIndex": 4,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.4.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:00.030Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.586Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.807Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:00.029Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:00.030Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.585Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.586Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.807Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.914Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.914Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:00.029Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.586Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/execution/stdout",
+                                    "shardIndex": 5,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.5.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:06.163Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.808Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.896Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.896Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:06.163Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:06.163Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:06.163Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.588Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.808Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.587Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.588Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.588Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/execution/stdout",
+                                    "shardIndex": 6,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.6.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:59.301Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.584Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.828Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:59.301Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.584Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.828Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:59.301Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:59.301Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.583Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/execution/stdout",
+                                    "shardIndex": 7,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.7.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:56.540Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.807Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.586Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.586Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:56.539Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:56.540Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.586Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.918Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:56.539Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.807Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.918Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.586Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/execution/stdout",
+                                    "shardIndex": 8,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.8.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:50.595Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.808Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.586Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.587Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.840Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:50.595Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:50.595Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:50.595Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.587Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.808Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.840Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.587Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/execution/stdout",
+                                    "shardIndex": 9,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.9.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:57.122Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.582Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.582Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.851Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.851Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:57.122Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:57.122Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:57.122Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.582Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.582Z"
+                                  }]
+                                },
+                                "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                                "id": "1efa7813-b461-491a-b984-baba4bf5794a",
+                                "inputs": {
+                                  "number_of_hits": null,
+                                  "filter": 1,
+                                  "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                  "evalue": "1e-15",
+                                  "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                                },
+                                "status": "Failed",
+                                "parentWorkflowId": "9d9c5052-61a7-448d-8e2e-fdaaaba9209c",
+                                "end": "2019-10-14T14:53:06.522Z",
+                                "start": "2019-10-14T14:52:14.463Z"
+                              },
+                              "shardIndex": 0,
+                              "inputs": {
+                                "number_of_hits": null,
+                                "filter": 1,
+                                "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                "evalue": "1e-15",
+                                "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                              },
+                              "failures": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                        "causedBy": []
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                        "causedBy": []
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                        "causedBy": []
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }],
+                                "message": "Workflow failed"
+                              }],
+                              "end": "2019-10-14T14:53:06.521Z",
+                              "attempt": 1,
+                              "executionEvents": [{
+                                "startTime": "2019-10-14T14:52:14.463Z",
+                                "description": "WaitingForValueStore",
+                                "endTime": "2019-10-14T14:52:14.463Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.463Z",
+                                "description": "SubWorkflowPreparingState",
+                                "endTime": "2019-10-14T14:52:14.466Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.462Z",
+                                "description": "SubWorkflowPendingState",
+                                "endTime": "2019-10-14T14:52:14.463Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.466Z",
+                                "description": "SubWorkflowRunningState",
+                                "endTime": "2019-10-14T14:53:06.522Z"
+                              }],
+                              "start": "2019-10-14T14:52:14.462Z"
+                            }]
+                          },
+                          "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                          "id": "9d9c5052-61a7-448d-8e2e-fdaaaba9209c",
+                          "inputs": {
+                            "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"],
+                            "id_blast_database": {
+                              "number_of_hits": null,
+                              "reconcile_lca_or_random": null,
+                              "summary_taxon": null,
+                              "db_index_cdb": null,
+                              "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                              "max_informative_taxa_hits": null,
+                              "minimum_taxa_hits": null,
+                              "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                              "min_match_identity_pct": 95.0,
+                              "filter": 1,
+                              "report_style": null,
+                              "database_name": "vector",
+                              "evalue": "1e-15",
+                              "target_taxon_id": 9606,
+                              "min_match_length_bp": 25
+                            }
+                          },
+                          "status": "Failed",
+                          "parentWorkflowId": "220e376c-a8ac-49ca-9289-522e9a1105b8",
+                          "end": "2019-10-14T14:53:07.500Z",
+                          "start": "2019-10-14T14:52:10.381Z"
+                        },
+                        "shardIndex": 0,
+                        "inputs": {
+                          "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"],
+                          "id_blast_database": {
+                            "number_of_hits": null,
+                            "reconcile_lca_or_random": null,
+                            "summary_taxon": null,
+                            "db_index_cdb": null,
+                            "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                            "max_informative_taxa_hits": null,
+                            "minimum_taxa_hits": null,
+                            "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                            "min_match_identity_pct": 95.0,
+                            "filter": 1,
+                            "report_style": null,
+                            "database_name": "vector",
+                            "evalue": "1e-15",
+                            "target_taxon_id": 9606,
+                            "min_match_length_bp": 25
+                          }
+                        },
+                        "failures": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                    "causedBy": []
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                    "causedBy": []
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                    "causedBy": []
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }],
+                            "message": "Workflow failed"
+                          }],
+                          "message": "Workflow failed"
+                        }],
+                        "end": "2019-10-14T14:53:07.500Z",
+                        "attempt": 1,
+                        "executionEvents": [{
+                          "startTime": "2019-10-14T14:52:10.380Z",
+                          "description": "WaitingForValueStore",
+                          "endTime": "2019-10-14T14:52:10.381Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.387Z",
+                          "description": "SubWorkflowRunningState",
+                          "endTime": "2019-10-14T14:53:07.500Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.381Z",
+                          "description": "SubWorkflowPreparingState",
+                          "endTime": "2019-10-14T14:52:10.387Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.380Z",
+                          "description": "SubWorkflowPendingState",
+                          "endTime": "2019-10-14T14:52:10.380Z"
+                        }],
+                        "start": "2019-10-14T14:52:10.380Z"
+                      }]
+                    },
+                    "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                    "id": "220e376c-a8ac-49ca-9289-522e9a1105b8",
+                    "inputs": {
+                      "sample_name": "C836.BICR_18.2.chr22",
+                      "id_blast_database": {
+                        "number_of_hits": null,
+                        "reconcile_lca_or_random": null,
+                        "summary_taxon": null,
+                        "db_index_cdb": null,
+                        "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                        "max_informative_taxa_hits": null,
+                        "minimum_taxa_hits": null,
+                        "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                        "min_match_identity_pct": 95.0,
+                        "filter": 1,
+                        "report_style": null,
+                        "database_name": "vector",
+                        "evalue": "1e-15",
+                        "target_taxon_id": 9606,
+                        "min_match_length_bp": 25
+                      },
+                      "read_sets": [["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]]
+                    },
+                    "status": "Failed",
+                    "parentWorkflowId": "44d7d360-b648-41c2-98c0-d24d9b2f10bd",
+                    "end": "2019-10-14T14:53:08.519Z",
+                    "start": "2019-10-14T14:52:06.294Z"
+                  },
+                  "shardIndex": 0,
+                  "inputs": {
+                    "sample_name": "C836.BICR_18.2.chr22",
+                    "id_blast_database": {
+                      "number_of_hits": null,
+                      "reconcile_lca_or_random": null,
+                      "summary_taxon": null,
+                      "db_index_cdb": null,
+                      "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                      "max_informative_taxa_hits": null,
+                      "minimum_taxa_hits": null,
+                      "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                      "min_match_identity_pct": 95.0,
+                      "filter": 1,
+                      "report_style": null,
+                      "database_name": "vector",
+                      "evalue": "1e-15",
+                      "target_taxon_id": 9606,
+                      "min_match_length_bp": 25
+                    },
+                    "read_sets": [["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]]
+                  },
+                  "failures": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }],
+                        "message": "Workflow failed"
+                      }],
+                      "message": "Workflow failed"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "end": "2019-10-14T14:53:08.519Z",
+                  "attempt": 1,
+                  "executionEvents": [{
+                    "startTime": "2019-10-14T14:52:06.294Z",
+                    "description": "SubWorkflowPreparingState",
+                    "endTime": "2019-10-14T14:52:06.300Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.293Z",
+                    "description": "WaitingForValueStore",
+                    "endTime": "2019-10-14T14:52:06.294Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.300Z",
+                    "description": "SubWorkflowRunningState",
+                    "endTime": "2019-10-14T14:53:08.520Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.293Z",
+                    "description": "SubWorkflowPendingState",
+                    "endTime": "2019-10-14T14:52:06.293Z"
+                  }],
+                  "start": "2019-10-14T14:52:06.293Z"
+                }, {
+                  "retryableFailure": false,
+                  "executionStatus": "Failed",
+                  "subWorkflowMetadata": {
+                    "workflowName": "contam_testing_assay_id",
+                    "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                    "calls": {
+                      "contam_testing_assay_id.contam_testing_set_id": [{
+                        "retryableFailure": false,
+                        "executionStatus": "Failed",
+                        "subWorkflowMetadata": {
+                          "workflowName": "contam_testing_set_id",
+                          "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                          "calls": {
+                            "contam_testing_set_id.contam_testing_set_id_by_volume": [{
+                              "retryableFailure": false,
+                              "executionStatus": "Failed",
+                              "subWorkflowMetadata": {
+                                "workflowName": "contam_testing_set_id_by_volume",
+                                "rootWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+                                "calls": {
+                                  "contam_testing_set_id_by_volume.id_blast": [{
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/execution/stdout",
+                                    "shardIndex": 0,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.1.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:02.393Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.583Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.814Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.831Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:02.393Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:02.393Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.831Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:02.393Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.814Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.583Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/execution/stdout",
+                                    "shardIndex": 1,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.10.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                            "causedBy": []
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:02.862Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:02.861Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:02.862Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.884Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:02.861Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.583Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.884Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.583Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/execution/stdout",
+                                    "shardIndex": 2,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.2.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:56.532Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.907Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:56.532Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:56.532Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.907Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:56.532Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.582Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.583Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.582Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/execution/stdout",
+                                    "shardIndex": 3,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.3.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:01.243Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:53:01.243Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:01.243Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.585Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.830Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.830Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:01.243Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.584Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.585Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.584Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/execution/stdout",
+                                    "shardIndex": 4,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.4.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:51.282Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.901Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.901Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:51.282Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.585Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.585Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.585Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:51.282Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:51.282Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.585Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/execution/stdout",
+                                    "shardIndex": 5,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.5.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:52:57.492Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.807Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.881Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.588Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.881Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:52:57.492Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.807Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:57.492Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:52:57.492Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.587Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.588Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.587Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/execution/stdout",
+                                    "shardIndex": 6,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.6.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:05.012Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.584Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.909Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.909Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:05.012Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:05.012Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:05.012Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.583Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.584Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.583Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/execution/stdout",
+                                    "shardIndex": 7,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.7.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:00.351Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.806Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:00.351Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:00.351Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.836Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:00.351Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.586Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.586Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.806Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.836Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.586Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.586Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/execution/stdout",
+                                    "shardIndex": 8,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.8.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:01.503Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.807Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.832Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:01.503Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:01.503Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.587Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.807Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.586Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.587Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.832Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:01.503Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.587Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/execution/stdout",
+                                    "shardIndex": 9,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.9.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:53:00.981Z",
+                                    "stderr": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:52:18.582Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:53:00.980Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:53:00.981Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.896Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:53:00.980Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.582Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:52:18.582Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:52:18.805Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:52:18.805Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:52:18.896Z"
+                                    }],
+                                    "start": "2019-10-14T14:52:18.582Z"
+                                  }]
+                                },
+                                "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                                "id": "ed7df906-a3eb-4fb2-a121-53a0b3ec65d5",
+                                "inputs": {
+                                  "number_of_hits": null,
+                                  "filter": 0,
+                                  "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                  "evalue": "1e-12",
+                                  "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                                },
+                                "status": "Failed",
+                                "parentWorkflowId": "16e68df5-eb17-490c-8b37-fa56c5a6da3e",
+                                "end": "2019-10-14T14:53:05.501Z",
+                                "start": "2019-10-14T14:52:14.463Z"
+                              },
+                              "shardIndex": 0,
+                              "inputs": {
+                                "number_of_hits": null,
+                                "filter": 0,
+                                "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                "evalue": "1e-12",
+                                "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                              },
+                              "failures": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                        "causedBy": []
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }],
+                                "message": "Workflow failed"
+                              }],
+                              "end": "2019-10-14T14:53:05.501Z",
+                              "attempt": 1,
+                              "executionEvents": [{
+                                "startTime": "2019-10-14T14:52:14.467Z",
+                                "description": "SubWorkflowRunningState",
+                                "endTime": "2019-10-14T14:53:05.501Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.463Z",
+                                "description": "SubWorkflowPreparingState",
+                                "endTime": "2019-10-14T14:52:14.467Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.462Z",
+                                "description": "SubWorkflowPendingState",
+                                "endTime": "2019-10-14T14:52:14.463Z"
+                              }, {
+                                "startTime": "2019-10-14T14:52:14.463Z",
+                                "description": "WaitingForValueStore",
+                                "endTime": "2019-10-14T14:52:14.463Z"
+                              }],
+                              "start": "2019-10-14T14:52:14.462Z"
+                            }]
+                          },
+                          "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                          "id": "16e68df5-eb17-490c-8b37-fa56c5a6da3e",
+                          "inputs": {
+                            "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"],
+                            "id_blast_database": {
+                              "number_of_hits": null,
+                              "reconcile_lca_or_random": null,
+                              "summary_taxon": null,
+                              "db_index_cdb": null,
+                              "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                              "max_informative_taxa_hits": null,
+                              "minimum_taxa_hits": null,
+                              "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                              "min_match_identity_pct": 99.0,
+                              "filter": 0,
+                              "report_style": null,
+                              "database_name": "ngs_adaptor",
+                              "evalue": "1e-12",
+                              "target_taxon_id": 9606,
+                              "min_match_length_bp": 35
+                            }
+                          },
+                          "status": "Failed",
+                          "parentWorkflowId": "bc2e87de-574c-41b8-b8df-5c0c1603b1de",
+                          "end": "2019-10-14T14:53:06.480Z",
+                          "start": "2019-10-14T14:52:10.381Z"
+                        },
+                        "shardIndex": 0,
+                        "inputs": {
+                          "fa_files": ["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"],
+                          "id_blast_database": {
+                            "number_of_hits": null,
+                            "reconcile_lca_or_random": null,
+                            "summary_taxon": null,
+                            "db_index_cdb": null,
+                            "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                            "max_informative_taxa_hits": null,
+                            "minimum_taxa_hits": null,
+                            "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                            "min_match_identity_pct": 99.0,
+                            "filter": 0,
+                            "report_style": null,
+                            "database_name": "ngs_adaptor",
+                            "evalue": "1e-12",
+                            "target_taxon_id": 9606,
+                            "min_match_length_bp": 35
+                          }
+                        },
+                        "failures": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }],
+                            "message": "Workflow failed"
+                          }],
+                          "message": "Workflow failed"
+                        }],
+                        "end": "2019-10-14T14:53:06.480Z",
+                        "attempt": 1,
+                        "executionEvents": [{
+                          "startTime": "2019-10-14T14:52:10.380Z",
+                          "description": "SubWorkflowPendingState",
+                          "endTime": "2019-10-14T14:52:10.380Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.381Z",
+                          "description": "SubWorkflowPreparingState",
+                          "endTime": "2019-10-14T14:52:10.387Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.380Z",
+                          "description": "WaitingForValueStore",
+                          "endTime": "2019-10-14T14:52:10.381Z"
+                        }, {
+                          "startTime": "2019-10-14T14:52:10.387Z",
+                          "description": "SubWorkflowRunningState",
+                          "endTime": "2019-10-14T14:53:06.480Z"
+                        }],
+                        "start": "2019-10-14T14:52:10.380Z"
+                      }]
+                    },
+                    "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+                    "id": "bc2e87de-574c-41b8-b8df-5c0c1603b1de",
+                    "inputs": {
+                      "sample_name": "C836.BICR_18.2.chr22",
+                      "id_blast_database": {
+                        "number_of_hits": null,
+                        "reconcile_lca_or_random": null,
+                        "summary_taxon": null,
+                        "db_index_cdb": null,
+                        "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                        "max_informative_taxa_hits": null,
+                        "minimum_taxa_hits": null,
+                        "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                        "min_match_identity_pct": 99.0,
+                        "filter": 0,
+                        "report_style": null,
+                        "database_name": "ngs_adaptor",
+                        "evalue": "1e-12",
+                        "target_taxon_id": 9606,
+                        "min_match_length_bp": 35
+                      },
+                      "read_sets": [["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]]
+                    },
+                    "status": "Failed",
+                    "parentWorkflowId": "44d7d360-b648-41c2-98c0-d24d9b2f10bd",
+                    "end": "2019-10-14T14:53:07.500Z",
+                    "start": "2019-10-14T14:52:06.294Z"
+                  },
+                  "shardIndex": 1,
+                  "inputs": {
+                    "sample_name": "C836.BICR_18.2.chr22",
+                    "id_blast_database": {
+                      "number_of_hits": null,
+                      "reconcile_lca_or_random": null,
+                      "summary_taxon": null,
+                      "db_index_cdb": null,
+                      "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                      "max_informative_taxa_hits": null,
+                      "minimum_taxa_hits": null,
+                      "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                      "min_match_identity_pct": 99.0,
+                      "filter": 0,
+                      "report_style": null,
+                      "database_name": "ngs_adaptor",
+                      "evalue": "1e-12",
+                      "target_taxon_id": 9606,
+                      "min_match_length_bp": 35
+                    },
+                    "read_sets": [["/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-fetch/shard-0/multi_lane_fetch/a13f3f8a-955e-416e-b330-45dd5ca45d37/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]]
+                  },
+                  "failures": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }],
+                        "message": "Workflow failed"
+                      }],
+                      "message": "Workflow failed"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "end": "2019-10-14T14:53:07.500Z",
+                  "attempt": 1,
+                  "executionEvents": [{
+                    "startTime": "2019-10-14T14:52:06.293Z",
+                    "description": "SubWorkflowPendingState",
+                    "endTime": "2019-10-14T14:52:06.293Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.294Z",
+                    "description": "SubWorkflowPreparingState",
+                    "endTime": "2019-10-14T14:52:06.300Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.293Z",
+                    "description": "WaitingForValueStore",
+                    "endTime": "2019-10-14T14:52:06.294Z"
+                  }, {
+                    "startTime": "2019-10-14T14:52:06.300Z",
+                    "description": "SubWorkflowRunningState",
+                    "endTime": "2019-10-14T14:53:07.500Z"
+                  }],
+                  "start": "2019-10-14T14:52:06.293Z"
+                }]
+              },
+              "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+              "id": "44d7d360-b648-41c2-98c0-d24d9b2f10bd",
+              "inputs": {
+                "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_prefix": null,
+                "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null,
+                "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_prefix": null,
+                "org_blast_databases": [{
+                  "number_of_hits": 10,
+                  "reconcile_lca_or_random": "lca",
+                  "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                  "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                  "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                  "max_informative_taxa_hits": 5,
+                  "minimum_taxa_hits": 2,
+                  "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                  "filter": 1,
+                  "database_name": "standard_org",
+                  "evalue": "1e-8",
+                  "target_taxon_id": 9606,
+                  "reporting_cutoff_percentage": null
+                }],
+                "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+                "contam_testing_sample.count_blast_matches_non_rrna.cdb_index_mapping_taxon_ids_to_paths": null,
+                "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_prefix": null,
+                "create_homopolymer_report": false,
+                "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                "number_of_sets": 10,
+                "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+                "suppress_reads_homopolymer_cutoff": 0.0,
+                "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+                "sample_data": {
+                  "C836.BICR_18.2.chr22.Assay": {
+                    "right": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                    "left": ["/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz"]
+                  }
+                },
+                "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                "number_of_reads": 100000,
+                "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+                "contam_testing_sample.org_report.read_length": null,
+                "read_name_format": 0,
+                "sample_name": "C836.BICR_18.2.chr22",
+                "id_blast_databases": [{
+                  "number_of_hits": null,
+                  "reconcile_lca_or_random": null,
+                  "summary_taxon": null,
+                  "db_index_cdb": null,
+                  "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                  "max_informative_taxa_hits": null,
+                  "minimum_taxa_hits": null,
+                  "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                  "min_match_identity_pct": 95.0,
+                  "filter": 1,
+                  "report_style": null,
+                  "database_name": "vector",
+                  "evalue": "1e-15",
+                  "target_taxon_id": 9606,
+                  "min_match_length_bp": 25
+                }, {
+                  "number_of_hits": null,
+                  "reconcile_lca_or_random": null,
+                  "summary_taxon": null,
+                  "db_index_cdb": null,
+                  "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                  "max_informative_taxa_hits": null,
+                  "minimum_taxa_hits": null,
+                  "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                  "min_match_identity_pct": 99.0,
+                  "filter": 0,
+                  "report_style": null,
+                  "database_name": "ngs_adaptor",
+                  "evalue": "1e-12",
+                  "target_taxon_id": 9606,
+                  "min_match_length_bp": 35
+                }],
+                "contam_testing_sample.count_blast_matches_non_rrna.cdb_index_sequence_ids_into_taxon_ids": null,
+                "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                "fq_fa_or_bam": "fq",
+                "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_read_details_report": null
+              },
+              "status": "Failed",
+              "parentWorkflowId": "9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b",
+              "end": "2019-10-14T14:53:09.530Z",
+              "start": "2019-10-14T14:51:42.817Z"
+            },
+            "shardIndex": 0,
+            "inputs": {
+              "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_prefix": null,
+              "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null,
+              "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_prefix": null,
+              "org_blast_databases": [{
+                "number_of_hits": 10,
+                "reconcile_lca_or_random": "lca",
+                "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                "max_informative_taxa_hits": 5,
+                "minimum_taxa_hits": 2,
+                "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                "filter": 1,
+                "database_name": "standard_org",
+                "evalue": "1e-8",
+                "target_taxon_id": 9606,
+                "reporting_cutoff_percentage": null
+              }],
+              "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+              "contam_testing_sample.count_blast_matches_non_rrna.cdb_index_mapping_taxon_ids_to_paths": null,
+              "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_prefix": null,
+              "create_homopolymer_report": false,
+              "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+              "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+              "number_of_sets": 10,
+              "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+              "suppress_reads_homopolymer_cutoff": 0.0,
+              "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+              "sample_data": {
+                "C836.BICR_18.2.chr22.Assay": {
+                  "right": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                  "left": ["/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz"]
+                }
+              },
+              "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+              "number_of_reads": 100000,
+              "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+              "contam_testing_sample.org_report.read_length": null,
+              "read_name_format": 0,
+              "sample_name": "C836.BICR_18.2.chr22",
+              "id_blast_databases": [{
+                "number_of_hits": null,
+                "reconcile_lca_or_random": null,
+                "summary_taxon": null,
+                "db_index_cdb": null,
+                "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                "max_informative_taxa_hits": null,
+                "minimum_taxa_hits": null,
+                "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                "min_match_identity_pct": 95.0,
+                "filter": 1,
+                "report_style": null,
+                "database_name": "vector",
+                "evalue": "1e-15",
+                "target_taxon_id": 9606,
+                "min_match_length_bp": 25
+              }, {
+                "number_of_hits": null,
+                "reconcile_lca_or_random": null,
+                "summary_taxon": null,
+                "db_index_cdb": null,
+                "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                "max_informative_taxa_hits": null,
+                "minimum_taxa_hits": null,
+                "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                "min_match_identity_pct": 99.0,
+                "filter": 0,
+                "report_style": null,
+                "database_name": "ngs_adaptor",
+                "evalue": "1e-12",
+                "target_taxon_id": 9606,
+                "min_match_length_bp": 35
+              }],
+              "contam_testing_sample.count_blast_matches_non_rrna.cdb_index_sequence_ids_into_taxon_ids": null,
+              "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+              "fq_fa_or_bam": "fq",
+              "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_read_details_report": null
+            },
+            "failures": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "message": "Workflow failed"
+                }],
+                "message": "Workflow failed"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "message": "Workflow failed"
+                }],
+                "message": "Workflow failed"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "message": "Workflow failed"
+                }],
+                "message": "Workflow failed"
+              }],
+              "message": "Workflow failed"
+            }],
+            "end": "2019-10-14T14:53:09.530Z",
+            "attempt": 1,
+            "executionEvents": [{
+              "startTime": "2019-10-14T14:51:42.817Z",
+              "description": "WaitingForValueStore",
+              "endTime": "2019-10-14T14:51:42.817Z"
+            }, {
+              "startTime": "2019-10-14T14:51:42.816Z",
+              "description": "SubWorkflowPendingState",
+              "endTime": "2019-10-14T14:51:42.817Z"
+            }, {
+              "startTime": "2019-10-14T14:51:42.828Z",
+              "description": "SubWorkflowRunningState",
+              "endTime": "2019-10-14T14:53:09.530Z"
+            }, {
+              "startTime": "2019-10-14T14:51:42.817Z",
+              "description": "SubWorkflowPreparingState",
+              "endTime": "2019-10-14T14:51:42.828Z"
+            }],
+            "start": "2019-10-14T14:51:42.815Z"
+          }]
+        },
+        "id": "9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b",
+        "inputs": {
+          "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+          "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+          "create_homopolymer_report": null,
+          "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+          "suppress_reads_homopolymer_cutoff": null,
+          "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_prefix": null,
+          "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null
+        },
+        "status": "Failed",
+        "parentWorkflowId": "e0959413-04c5-4434-a676-0fd1601f910f",
+        "end": "2019-10-14T14:53:10.532Z",
+        "start": "2019-10-14T14:51:37.618Z"
+      },
+      "shardIndex": -1,
+      "inputs": {
+        "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+        "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+        "create_homopolymer_report": null,
+        "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+        "suppress_reads_homopolymer_cutoff": null,
+        "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_prefix": null,
+        "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null
+      },
+      "failures": [{
+        "causedBy": [{
+          "causedBy": [{
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }],
+                "message": "Workflow failed"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }, {
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }],
+                "message": "Workflow failed"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }, {
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }],
+                "message": "Workflow failed"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }],
+          "message": "Workflow failed"
+        }],
+        "message": "Workflow failed"
+      }],
+      "end": "2019-10-14T14:53:10.532Z",
+      "attempt": 1,
+      "executionEvents": [{
+        "startTime": "2019-10-14T14:51:37.609Z",
+        "description": "SubWorkflowPendingState",
+        "endTime": "2019-10-14T14:51:37.615Z"
+      }, {
+        "startTime": "2019-10-14T14:51:37.618Z",
+        "description": "SubWorkflowPreparingState",
+        "endTime": "2019-10-14T14:51:37.646Z"
+      }, {
+        "startTime": "2019-10-14T14:51:37.615Z",
+        "description": "WaitingForValueStore",
+        "endTime": "2019-10-14T14:51:37.618Z"
+      }, {
+        "startTime": "2019-10-14T14:51:37.646Z",
+        "description": "SubWorkflowRunningState",
+        "endTime": "2019-10-14T14:53:10.532Z"
+      }],
+      "start": "2019-10-14T14:51:37.607Z"
+    }]
+  },
+  "outputs": {
+
+  },
+  "workflowRoot": "/Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f",
+  "actualWorkflowLanguage": "WDL",
+  "id": "e0959413-04c5-4434-a676-0fd1601f910f",
+  "inputs": {
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_prefix": null,
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null,
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.count_blast_matches_non_rrna.cdb_index_sequence_ids_into_taxon_ids": null,
+    "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_read_details_report": null,
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.org_report.read_length": null,
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+    "use_total_retrieval_sequences": null,
+    "taxon_names_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/term_data.cdb",
+    "number_of_reads": 100000
+  },
+  "labels": {
+    "cromwell-workflow-id": "cromwell-e0959413-04c5-4434-a676-0fd1601f910f"
+  },
+  "submission": "2019-10-14T14:51:33.833Z",
+  "status": "Failed",
+  "failures": [{
+    "causedBy": [{
+      "causedBy": [{
+        "causedBy": [{
+          "causedBy": [{
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                      "causedBy": []
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/bc2e87de-574c-41b8-b8df-5c0c1603b1de/call-contam_testing_set_id/shard-0/contam_testing_set_id/16e68df5-eb17-490c-8b37-fa56c5a6da3e/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/ed7df906-a3eb-4fb2-a121-53a0b3ec65d5/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }],
+          "message": "Workflow failed"
+        }, {
+          "causedBy": [{
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/0018baac-191a-45ee-882f-36808a731b8e/call-contam_testing_set_org/shard-0/contam_testing_set_org/38c2ac67-c3c3-4fa8-996d-995fae040a0f/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/6717f340-b948-4e97-ac2c-bdba793893f5/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }],
+          "message": "Workflow failed"
+        }, {
+          "causedBy": [{
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data/cromwell-executions/test_contam_testing/e0959413-04c5-4434-a676-0fd1601f910f/call-contam_testing/contam_testing/9fa0eb2f-ee08-47b1-9aec-1ff2973efb2b/call-contam_testing_sample/shard-0/contam_testing_sample/44d7d360-b648-41c2-98c0-d24d9b2f10bd/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/220e376c-a8ac-49ca-9289-522e9a1105b8/call-contam_testing_set_id/shard-0/contam_testing_set_id/9d9c5052-61a7-448d-8e2e-fdaaaba9209c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/1efa7813-b461-491a-b984-baba4bf5794a/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }],
+          "message": "Workflow failed"
+        }],
+        "message": "Workflow failed"
+      }],
+      "message": "Workflow failed"
+    }],
+    "message": "Workflow failed"
+  }],
+  "end": "2019-10-14T14:53:11.471Z",
+  "start": "2019-10-14T14:51:33.913Z"
+}

--- a/tests/test_cromwell/metadata47.json
+++ b/tests/test_cromwell/metadata47.json
@@ -1,0 +1,5613 @@
+{
+  "workflowProcessingEvents": [{
+    "cromwellId": "cromid-4fdf6b8",
+    "description": "Finished",
+    "timestamp": "2019-10-14T14:59:58.853Z",
+    "cromwellVersion": "47"
+  }, {
+    "cromwellId": "cromid-4fdf6b8",
+    "description": "PickedUp",
+    "timestamp": "2019-10-14T14:58:17.169Z",
+    "cromwellVersion": "47"
+  }],
+  "actualWorkflowLanguageVersion": "Biscayne",
+  "submittedFiles": {
+    "workflow": "version development\n\nimport \"contam_testing.wdl\" as contam_testing\n\ntask sort {\n\n  input {\n    File input_file String output_file\n  }\n\n   command <<<\n     sort ~{input_file} > ~{output_file}\n   >>>\n\n   runtime {\n     docker: \"debian:stretch-slim\"\n   }\n\n   output {\n     File sorted_output = \"${output_file}\"\n   }\n\n}\n\nworkflow test_contam_testing {\n\n  input {\n        Map[String, Map[String, Pair[Array[File], File]]] samples\n        Array[OrgBlastDB]+ org_blast_databases\n        Array[IDBlastDB] id_blast_databases\n        File taxon_names_cdb\n        File taxon_paths_cdb # AKA cdb_index_mapping_taxon_ids_to_paths\n        String output_prefix\n        Boolean? create_homopolymer_report\n        Float? suppress_reads_homopolymer_cutoff\n        Boolean? use_total_retrieval_sequences\n        Int read_name_format\n        Int? number_of_reads\n        Int? number_of_sets\n        String? fq_fa_or_bam\n  }\n\n  call contam_testing.contam_testing {\n    input:\n        samples = samples,\n        org_blast_databases = org_blast_databases,\n        id_blast_databases = id_blast_databases,\n        taxon_names_cdb = taxon_names_cdb,\n        taxon_paths_cdb = taxon_paths_cdb,\n        output_prefix = output_prefix,\n        create_homopolymer_report = create_homopolymer_report,\n        suppress_reads_homopolymer_cutoff = suppress_reads_homopolymer_cutoff,\n        use_total_retrieval_sequences = use_total_retrieval_sequences,\n        read_name_format = read_name_format,\n        number_of_reads = number_of_reads,\n        number_of_sets = number_of_sets,\n        fq_fa_or_bam = fq_fa_or_bam\n  }\n\n  call sort {\n    input:\n      input_file=contam_testing.final_org_hit_based_reports[1],\n      output_file=\"sorted_final_org_hit_based_reports\"\n  }\n\n  output {\n    Array[File] org_hit_based = [sort.sorted_output]\n    Array[File] org_read_details = contam_testing.final_org_read_details_reports\n    Array[File] org_read_based = contam_testing.final_org_read_based_reports\n  }\n\n}",
+    "root": "",
+    "options": "{\n\n}",
+    "inputs": "{\"test_contam_testing.id_blast_databases\": [{\"blast_database_volumes\": [\"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\"], \"database_name\": \"vector\", \"evalue\": \"1e-15\", \"filter\": \"1\", \"friendly_names\": [[\"2\", \"Eubacteria\"], [\"2157\", \"Archaea\"], [\"4751\", \"Fungi\"], [\"6231\", \"Nematodes\"], [\"6447\", \"Molusks\"], [\"6656\", \"Arthropods\"], [\"9263\", \"Marsupials\"], [\"9443\", \"Primates\"], [\"9539\", \"Macaques\"], [\"9541\", \"Cyno (M. fascicularis)\"], [\"9606\", \"Human\"], [\"9989\", \"Rodents\"], [\"10029\", \"CHO\"], [\"10090\", \"Mouse\"], [\"10116\", \"Rat\"], [\"10239\", \"Viruses\"], [\"33090\", \"Green Plants\"], [\"33208\", \"Animals\"], [\"40674\", \"Mammals\"], [\"50557\", \"Insects\"], [\"314295\", \"Apes\"]], \"min_match_identity_pct\": \"95\", \"min_match_length_bp\": \"25\", \"target_taxon_id\": \"9606\"}, {\"blast_database_volumes\": [\"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\"], \"database_name\": \"ngs_adaptor\", \"evalue\": \"1e-12\", \"filter\": \"0\", \"friendly_names\": [[\"2\", \"Eubacteria\"], [\"2157\", \"Archaea\"], [\"4751\", \"Fungi\"], [\"6231\", \"Nematodes\"], [\"6447\", \"Molusks\"], [\"6656\", \"Arthropods\"], [\"9263\", \"Marsupials\"], [\"9443\", \"Primates\"], [\"9539\", \"Macaques\"], [\"9541\", \"Cyno (M. fascicularis)\"], [\"9606\", \"Human\"], [\"9989\", \"Rodents\"], [\"10029\", \"CHO\"], [\"10090\", \"Mouse\"], [\"10116\", \"Rat\"], [\"10239\", \"Viruses\"], [\"33090\", \"Green Plants\"], [\"33208\", \"Animals\"], [\"40674\", \"Mammals\"], [\"50557\", \"Insects\"], [\"314295\", \"Apes\"]], \"min_match_identity_pct\": \"99\", \"min_match_length_bp\": \"35\", \"target_taxon_id\": \"9606\"}], \"test_contam_testing.number_of_reads\": \"100000\", \"test_contam_testing.number_of_sets\": \"10\", \"test_contam_testing.org_blast_databases\": [{\"blast_database_volumes\": [\"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\"], \"database_name\": \"standard_org\", \"db_index_cdb\": \"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb\", \"evalue\": \"1e-8\", \"filter\": \"1\", \"friendly_names\": [[\"2\", \"Eubacteria\"], [\"2157\", \"Archaea\"], [\"4751\", \"Fungi\"], [\"6231\", \"Nematodes\"], [\"6447\", \"Molusks\"], [\"6656\", \"Arthropods\"], [\"9263\", \"Marsupials\"], [\"9443\", \"Primates\"], [\"9539\", \"Macaques\"], [\"9541\", \"Cyno (M. fascicularis)\"], [\"9606\", \"Human\"], [\"9989\", \"Rodents\"], [\"10029\", \"CHO\"], [\"10090\", \"Mouse\"], [\"10116\", \"Rat\"], [\"10239\", \"Viruses\"], [\"33090\", \"Green Plants\"], [\"33208\", \"Animals\"], [\"40674\", \"Mammals\"], [\"50557\", \"Insects\"], [\"314295\", \"Apes\"]], \"max_informative_taxa_hits\": \"5\", \"minimum_taxa_hits\": \"2\", \"number_of_hits\": \"10\", \"reconcile_lca_or_random\": \"lca\", \"summary_taxon\": [[\"2\", \"Eubacteria\"], [\"2157\", \"Archaea\"], [\"4751\", \"Fungi\"], [\"9443\", \"Primates\"], [\"9989\", \"Rodents\"], [\"10239\", \"Viruses\"], [\"33090\", \"Green Plants\"], [\"33208\", \"Animals\"], [\"40674\", \"Mammals\"], [\"314295\", \"Apes\"]], \"target_taxon_id\": \"9606\"}], \"test_contam_testing.output_prefix\": \"20190604164608\", \"test_contam_testing.read_name_format\": \"0\", \"test_contam_testing.taxon_names_cdb\": \"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/term_data.cdb\", \"test_contam_testing.taxon_paths_cdb\": \"/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb\", \"test_contam_testing.fq_fa_or_bam\": \"fq\", \"test_contam_testing.samples\": {\"C836.BICR_18.2.chr22\": {\"C836.BICR_18.2.chr22.Assay\": {\"left\": [\"/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz\"], \"right\": \"/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz\"}}}}",
+    "workflowUrl": "/Users/c252930/omics/contam/tests/test_contam_testing.wdl",
+    "labels": "{}"
+  },
+  "calls": {
+    "test_contam_testing.contam_testing": [{
+      "retryableFailure": false,
+      "executionStatus": "Failed",
+      "subWorkflowMetadata": {
+        "workflowName": "contam_testing",
+        "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+        "calls": {
+          "contam_testing.contam_testing_sample": [{
+            "retryableFailure": false,
+            "executionStatus": "Failed",
+            "subWorkflowMetadata": {
+              "workflowName": "contam_testing_sample",
+              "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+              "calls": {
+                "contam_testing_sample.fetch": [{
+                  "executionStatus": "Done",
+                  "subWorkflowMetadata": {
+                    "workflowName": "fetch",
+                    "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                    "calls": {
+                      "multi_lane_fetch.fastq_fetch": [{
+                        "executionStatus": "Done",
+                        "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/stdout",
+                        "backendStatus": "Done",
+                        "commandLine": "set -ex\n\nfq_fetch \\\n  -o C836.BICR_18.2.chr22.fq.gz \\\n  -n 100000 \\\n  -m 10  \\\n  -R 0 \\\n   \\\n   -F 0 \\\n   \\\n   \\\n   -S 0.0 \\\n  /cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/inputs/1995001600/C836.BICR_18.2.chr22.fq.gz\n\n# rename stats output so it doesn't get globbed with read sets.\nmv C836.BICR_18.2.chr22.fq.gz.stats C836.BICR_18.2.chr22.fq.gz_stats.stats",
+                        "shardIndex": 0,
+                        "outputs": {
+                          "homopolymer_report": [],
+                          "read_details_report": [],
+                          "stats_output": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/C836.BICR_18.2.chr22.fq.gz_stats.stats",
+                          "fq_read_sets": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                        },
+                        "runtimeAttributes": {
+                          "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/fq_fetch:0.1.0",
+                          "failOnStderr": "false",
+                          "maxRetries": "0",
+                          "continueOnReturnCode": "0"
+                        },
+                        "callCaching": {
+                          "allowResultReuse": false,
+                          "effectiveCallCachingMode": "CallCachingOff"
+                        },
+                        "inputs": {
+                          "read_summary_format": 0,
+                          "output_prefix": null,
+                          "suppress_reads_homopolymer_cutoff_defined": 0.0,
+                          "default_prefix": "C836.BICR_18.2.chr22.fq.gz",
+                          "output_read_details_report_defined": "",
+                          "default_number_of_sets": 10,
+                          "number_of_sets": 10,
+                          "default_read_name_multiply_for_homopolymer": false,
+                          "suppress_reads_homopolymer_cutoff": 0.0,
+                          "default_read_summary_format": 0,
+                          "is_fasta": false,
+                          "output_homopolymer_report_defined": "C836.BICR_18.2.chr22.fq.gz.homopolymer_report.txt",
+                          "number_of_reads": 100000,
+                          "default_number_of_reads": 100000,
+                          "read_name_multiply_for_homopolymer": false,
+                          "fastq": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                          "output_read_details_report": null,
+                          "output_homopolymer_report": null
+                        },
+                        "returnCode": 0,
+                        "jobId": "84613",
+                        "backend": "Local",
+                        "end": "2019-10-14T14:58:42.082Z",
+                        "dockerImageUsed": "elilillyco-omics-docker-lc.jfrog.io/qc/fq_fetch:0.1.0",
+                        "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/stderr",
+                        "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0",
+                        "attempt": 1,
+                        "executionEvents": [{
+                          "startTime": "2019-10-14T14:58:38.149Z",
+                          "description": "RunningJob",
+                          "endTime": "2019-10-14T14:58:42.082Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:37.402Z",
+                          "description": "RequestingExecutionToken",
+                          "endTime": "2019-10-14T14:58:38.086Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:38.091Z",
+                          "description": "PreparingJob",
+                          "endTime": "2019-10-14T14:58:38.149Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:37.392Z",
+                          "description": "Pending",
+                          "endTime": "2019-10-14T14:58:37.402Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:38.086Z",
+                          "description": "WaitingForValueStore",
+                          "endTime": "2019-10-14T14:58:38.091Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:42.082Z",
+                          "description": "UpdatingJobStore",
+                          "endTime": "2019-10-14T14:58:42.083Z"
+                        }],
+                        "start": "2019-10-14T14:58:37.383Z"
+                      }]
+                    },
+                    "outputs": {
+                      "multi_lane_fetch.read_details_report": [[]],
+                      "multi_lane_fetch.stats_output": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/C836.BICR_18.2.chr22.fq.gz_stats.stats"],
+                      "multi_lane_fetch.read_sets": [["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                      "multi_lane_fetch.homopolymer_report": [[]]
+                    },
+                    "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                    "id": "d89a7623-7e6d-4085-a1bb-7a4c897056ab",
+                    "inputs": {
+                      "multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+                      "read_summary_format": 0,
+                      "multi_lane_fetch.bam_fetch.output_read_details_report": null,
+                      "multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+                      "input_files": {
+                        "right": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                        "left": ["/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz"]
+                      },
+                      "multi_lane_fetch.fastq_fetch.output_prefix": null,
+                      "create_homopolymer_report": false,
+                      "number_of_sets": 10,
+                      "multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+                      "multi_lane_fetch.fasta_fetch.output_read_details_report": null,
+                      "multi_lane_fetch.bam_fetch.output_prefix": null,
+                      "suppress_reads_homopolymer_cutoff": 0.0,
+                      "multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+                      "number_of_reads": 100000,
+                      "multi_lane_fetch.fasta_fetch.output_prefix": null,
+                      "fq_fa_or_bam": "fq"
+                    },
+                    "status": "Succeeded",
+                    "parentWorkflowId": "f26876de-1857-4ad3-92bd-61df8d21da99",
+                    "end": "2019-10-14T14:58:46.570Z",
+                    "start": "2019-10-14T14:58:31.220Z"
+                  },
+                  "shardIndex": 0,
+                  "outputs": {
+                    "read_details_report": [[]],
+                    "stats_output": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/C836.BICR_18.2.chr22.fq.gz_stats.stats"],
+                    "read_sets": [["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                    "homopolymer_report": [[]]
+                  },
+                  "inputs": {
+                    "multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+                    "read_summary_format": 0,
+                    "multi_lane_fetch.bam_fetch.output_read_details_report": null,
+                    "multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+                    "input_files": {
+                      "right": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                      "left": ["/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz"]
+                    },
+                    "multi_lane_fetch.fastq_fetch.output_prefix": null,
+                    "create_homopolymer_report": false,
+                    "number_of_sets": 10,
+                    "multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+                    "multi_lane_fetch.fasta_fetch.output_read_details_report": null,
+                    "multi_lane_fetch.bam_fetch.output_prefix": null,
+                    "suppress_reads_homopolymer_cutoff": 0.0,
+                    "multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+                    "number_of_reads": 100000,
+                    "multi_lane_fetch.fasta_fetch.output_prefix": null,
+                    "fq_fa_or_bam": "fq"
+                  },
+                  "end": "2019-10-14T14:58:46.570Z",
+                  "attempt": 1,
+                  "executionEvents": [{
+                    "startTime": "2019-10-14T14:58:31.219Z",
+                    "description": "WaitingForValueStore",
+                    "endTime": "2019-10-14T14:58:31.220Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:31.219Z",
+                    "description": "SubWorkflowPendingState",
+                    "endTime": "2019-10-14T14:58:31.219Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:31.224Z",
+                    "description": "SubWorkflowRunningState",
+                    "endTime": "2019-10-14T14:58:46.570Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:31.220Z",
+                    "description": "SubWorkflowPreparingState",
+                    "endTime": "2019-10-14T14:58:31.224Z"
+                  }],
+                  "start": "2019-10-14T14:58:31.219Z"
+                }],
+                "contam_testing_sample.contam_testing_assay_org": [{
+                  "retryableFailure": false,
+                  "executionStatus": "Failed",
+                  "subWorkflowMetadata": {
+                    "workflowName": "contam_testing_assay_org",
+                    "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                    "calls": {
+                      "contam_testing_assay_org.contam_testing_set_org": [{
+                        "retryableFailure": false,
+                        "executionStatus": "Failed",
+                        "subWorkflowMetadata": {
+                          "workflowName": "contam_testing_set_org",
+                          "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                          "calls": {
+                            "contam_testing_set_org.contam_testing_set_org_by_volume": [{
+                              "retryableFailure": false,
+                              "executionStatus": "Failed",
+                              "subWorkflowMetadata": {
+                                "workflowName": "contam_testing_set_org_by_volume",
+                                "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                                "calls": {
+                                  "contam_testing_set_org_by_volume.org_blast": [{
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/execution/stdout",
+                                    "shardIndex": 0,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.1.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:41.560Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.866Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.867Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.867Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.085Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.156Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:41.560Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:41.560Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:41.561Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.085Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.156Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.866Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/execution/stdout",
+                                    "shardIndex": 1,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.10.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:46.739Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.867Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.867Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.867Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.106Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.106Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:46.739Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:46.739Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:46.739Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.867Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/execution/stdout",
+                                    "shardIndex": 2,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.2.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:36.219Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.090Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.869Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:36.218Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:36.218Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.868Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.869Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.221Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:36.218Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.090Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.221Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.868Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/execution/stdout",
+                                    "shardIndex": 3,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.3.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:44.168Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.082Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.085Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.085Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.199Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.866Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.866Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.866Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.082Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.199Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:44.168Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:44.168Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:44.168Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.866Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/execution/stdout",
+                                    "shardIndex": 4,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.4.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:39.897Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:39.897Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:39.897Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.868Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.867Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.868Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.121Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:39.897Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.091Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.121Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.091Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.867Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/execution/stdout",
+                                    "shardIndex": 5,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.5.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:45.027Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.203Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:45.027Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.868Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:45.027Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:45.027Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.084Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.203Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.868Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.868Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.084Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.868Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/execution/stdout",
+                                    "shardIndex": 6,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.6.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:42.439Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.085Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.181Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.875Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.085Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.869Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.875Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.181Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:42.439Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:42.439Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:42.439Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.869Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/execution/stdout",
+                                    "shardIndex": 7,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.7.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:33.808Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.867Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:33.808Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:33.808Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.085Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.867Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.867Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.085Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.213Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.213Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:33.808Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.867Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/execution/stdout",
+                                    "shardIndex": 8,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.8.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:39.496Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.867Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.084Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:39.496Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:39.496Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.169Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:39.496Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.084Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.169Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.867Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.867Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.867Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/execution/stdout",
+                                    "shardIndex": 9,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": 10,
+                                      "default_evalue": "1e-8",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9",
+                                      "evalue": "1e-8",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.9.rep_db.fa.02.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:45.377Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.085Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.194Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.869Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.869Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:45.377Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:45.377Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.869Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.194Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:45.377Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.085Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.869Z"
+                                  }]
+                                },
+                                "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                                "id": "563012ef-e593-42dc-9de0-f0a682ce23e3",
+                                "inputs": {
+                                  "read_summary_format": 0,
+                                  "number_of_hits": 10,
+                                  "reconcile_lca_or_random": "lca",
+                                  "contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                                  "contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                                  "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                                  "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                                  "max_informative_taxa_hits": 5,
+                                  "minimum_taxa_hits": 2,
+                                  "filter": 1,
+                                  "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                  "contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                                  "evalue": "1e-8",
+                                  "target_taxon_id": 9606,
+                                  "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                                },
+                                "status": "Failed",
+                                "parentWorkflowId": "d067c866-3be8-4db2-92e5-63d62f371751",
+                                "end": "2019-10-14T14:59:46.759Z",
+                                "start": "2019-10-14T14:58:57.746Z"
+                              },
+                              "shardIndex": 0,
+                              "inputs": {
+                                "read_summary_format": 0,
+                                "number_of_hits": 10,
+                                "reconcile_lca_or_random": "lca",
+                                "contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                                "contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                                "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                                "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                                "max_informative_taxa_hits": 5,
+                                "minimum_taxa_hits": 2,
+                                "filter": 1,
+                                "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                "contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                                "evalue": "1e-8",
+                                "target_taxon_id": 9606,
+                                "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                              },
+                              "failures": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }],
+                                "message": "Workflow failed"
+                              }],
+                              "end": "2019-10-14T14:59:46.759Z",
+                              "attempt": 1,
+                              "executionEvents": [{
+                                "startTime": "2019-10-14T14:58:57.752Z",
+                                "description": "SubWorkflowRunningState",
+                                "endTime": "2019-10-14T14:59:46.759Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.746Z",
+                                "description": "SubWorkflowPendingState",
+                                "endTime": "2019-10-14T14:58:57.746Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.746Z",
+                                "description": "SubWorkflowPreparingState",
+                                "endTime": "2019-10-14T14:58:57.752Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.746Z",
+                                "description": "WaitingForValueStore",
+                                "endTime": "2019-10-14T14:58:57.746Z"
+                              }],
+                              "start": "2019-10-14T14:58:57.745Z"
+                            }]
+                          },
+                          "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                          "id": "d067c866-3be8-4db2-92e5-63d62f371751",
+                          "inputs": {
+                            "read_summary_format": 0,
+                            "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                            "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                            "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                            "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                            "org_blast_database": {
+                              "number_of_hits": 10,
+                              "reconcile_lca_or_random": "lca",
+                              "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                              "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                              "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                              "max_informative_taxa_hits": 5,
+                              "minimum_taxa_hits": 2,
+                              "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                              "filter": 1,
+                              "database_name": "standard_org",
+                              "evalue": "1e-8",
+                              "target_taxon_id": 9606,
+                              "reporting_cutoff_percentage": null
+                            },
+                            "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                          },
+                          "status": "Failed",
+                          "parentWorkflowId": "7c70402f-acab-4840-aa94-9852834aef3f",
+                          "end": "2019-10-14T14:59:47.725Z",
+                          "start": "2019-10-14T14:58:53.668Z"
+                        },
+                        "shardIndex": 0,
+                        "inputs": {
+                          "read_summary_format": 0,
+                          "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                          "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                          "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                          "contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                          "org_blast_database": {
+                            "number_of_hits": 10,
+                            "reconcile_lca_or_random": "lca",
+                            "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                            "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                            "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                            "max_informative_taxa_hits": 5,
+                            "minimum_taxa_hits": 2,
+                            "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                            "filter": 1,
+                            "database_name": "standard_org",
+                            "evalue": "1e-8",
+                            "target_taxon_id": 9606,
+                            "reporting_cutoff_percentage": null
+                          },
+                          "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                        },
+                        "failures": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }],
+                            "message": "Workflow failed"
+                          }],
+                          "message": "Workflow failed"
+                        }],
+                        "end": "2019-10-14T14:59:47.725Z",
+                        "attempt": 1,
+                        "executionEvents": [{
+                          "startTime": "2019-10-14T14:58:53.667Z",
+                          "description": "SubWorkflowPendingState",
+                          "endTime": "2019-10-14T14:58:53.667Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.667Z",
+                          "description": "WaitingForValueStore",
+                          "endTime": "2019-10-14T14:58:53.668Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.675Z",
+                          "description": "SubWorkflowRunningState",
+                          "endTime": "2019-10-14T14:59:47.726Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.668Z",
+                          "description": "SubWorkflowPreparingState",
+                          "endTime": "2019-10-14T14:58:53.675Z"
+                        }],
+                        "start": "2019-10-14T14:58:53.667Z"
+                      }]
+                    },
+                    "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                    "id": "7c70402f-acab-4840-aa94-9852834aef3f",
+                    "inputs": {
+                      "read_summary_format": 0,
+                      "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                      "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                      "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                      "read_sets": [["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                      "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                      "org_blast_database": {
+                        "number_of_hits": 10,
+                        "reconcile_lca_or_random": "lca",
+                        "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                        "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                        "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                        "max_informative_taxa_hits": 5,
+                        "minimum_taxa_hits": 2,
+                        "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                        "filter": 1,
+                        "database_name": "standard_org",
+                        "evalue": "1e-8",
+                        "target_taxon_id": 9606,
+                        "reporting_cutoff_percentage": null
+                      },
+                      "sample_name": "C836.BICR_18.2.chr22"
+                    },
+                    "status": "Failed",
+                    "parentWorkflowId": "f26876de-1857-4ad3-92bd-61df8d21da99",
+                    "end": "2019-10-14T14:59:48.746Z",
+                    "start": "2019-10-14T14:58:49.578Z"
+                  },
+                  "shardIndex": 0,
+                  "inputs": {
+                    "read_summary_format": 0,
+                    "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                    "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                    "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                    "read_sets": [["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                    "contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                    "org_blast_database": {
+                      "number_of_hits": 10,
+                      "reconcile_lca_or_random": "lca",
+                      "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                      "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                      "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                      "max_informative_taxa_hits": 5,
+                      "minimum_taxa_hits": 2,
+                      "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                      "filter": 1,
+                      "database_name": "standard_org",
+                      "evalue": "1e-8",
+                      "target_taxon_id": 9606,
+                      "reporting_cutoff_percentage": null
+                    },
+                    "sample_name": "C836.BICR_18.2.chr22"
+                  },
+                  "failures": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }],
+                        "message": "Workflow failed"
+                      }],
+                      "message": "Workflow failed"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "end": "2019-10-14T14:59:48.746Z",
+                  "attempt": 1,
+                  "executionEvents": [{
+                    "startTime": "2019-10-14T14:58:49.585Z",
+                    "description": "SubWorkflowRunningState",
+                    "endTime": "2019-10-14T14:59:48.746Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.579Z",
+                    "description": "SubWorkflowPreparingState",
+                    "endTime": "2019-10-14T14:58:49.585Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.578Z",
+                    "description": "WaitingForValueStore",
+                    "endTime": "2019-10-14T14:58:49.579Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.577Z",
+                    "description": "SubWorkflowPendingState",
+                    "endTime": "2019-10-14T14:58:49.578Z"
+                  }],
+                  "start": "2019-10-14T14:58:49.577Z"
+                }],
+                "contam_testing_sample.contam_testing_assay_id": [{
+                  "retryableFailure": false,
+                  "executionStatus": "Failed",
+                  "subWorkflowMetadata": {
+                    "workflowName": "contam_testing_assay_id",
+                    "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                    "calls": {
+                      "contam_testing_assay_id.contam_testing_set_id": [{
+                        "retryableFailure": false,
+                        "executionStatus": "Failed",
+                        "subWorkflowMetadata": {
+                          "workflowName": "contam_testing_set_id",
+                          "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                          "calls": {
+                            "contam_testing_set_id.contam_testing_set_id_by_volume": [{
+                              "retryableFailure": false,
+                              "executionStatus": "Failed",
+                              "subWorkflowMetadata": {
+                                "workflowName": "contam_testing_set_id_by_volume",
+                                "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                                "calls": {
+                                  "contam_testing_set_id_by_volume.id_blast": [{
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/execution/stdout",
+                                    "shardIndex": 0,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.1.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                            "causedBy": []
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:43.047Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.088Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.117Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.117Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:43.047Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.863Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:43.047Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:43.047Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.088Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.862Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.863Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.863Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/execution/stdout",
+                                    "shardIndex": 1,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.10.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:42.568Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:42.568Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:42.568Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.085Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.207Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:42.568Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.085Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.207Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.860Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.860Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.860Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/execution/stdout",
+                                    "shardIndex": 2,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.2.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:47.658Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:47.658Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:47.658Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.190Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:47.658Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.859Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.084Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.190Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.084Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.859Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/execution/stdout",
+                                    "shardIndex": 3,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.3.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:45.340Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.142Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:45.339Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.862Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.088Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.142Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.862Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.862Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.088Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:45.339Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:45.340Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.862Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/execution/stdout",
+                                    "shardIndex": 4,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.4.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:42.918Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.115Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:42.918Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.084Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.859Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:42.918Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:42.918Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.084Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.115Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.858Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/execution/stdout",
+                                    "shardIndex": 5,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.5.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:37.668Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.088Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:37.668Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:37.668Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.088Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.224Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.224Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:37.668Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.862Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.861Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.862Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.861Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/execution/stdout",
+                                    "shardIndex": 6,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.6.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:32.752Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.088Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.138Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:32.751Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.860Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.861Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:32.751Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:32.752Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.088Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.138Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.861Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.861Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/execution/stdout",
+                                    "shardIndex": 7,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.7.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:46.889Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.859Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.093Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.125Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.093Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:46.889Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:46.889Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.125Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:46.889Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.858Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/execution/stdout",
+                                    "shardIndex": 8,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.8.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:47.397Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.858Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:47.397Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:47.397Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.083Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.083Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.111Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.111Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:47.397Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.857Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/execution/stdout",
+                                    "shardIndex": 9,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-15",
+                                      "default_number_of_hits": 10,
+                                      "filter": 1,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                      "default_filter": 1,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9",
+                                      "evalue": "1e-15",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.9.synthetic.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:51.807Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.113Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:51.807Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:51.807Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:51.807Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.857Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.858Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.088Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.088Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.113Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.857Z"
+                                  }]
+                                },
+                                "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                                "id": "0110679b-ed53-44e0-b7b5-ba1ac61c9282",
+                                "inputs": {
+                                  "number_of_hits": null,
+                                  "filter": 1,
+                                  "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                  "evalue": "1e-15",
+                                  "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                                },
+                                "status": "Failed",
+                                "parentWorkflowId": "1d400c41-5554-4f24-b1de-40072f3d9846",
+                                "end": "2019-10-14T14:59:51.838Z",
+                                "start": "2019-10-14T14:58:57.746Z"
+                              },
+                              "shardIndex": 0,
+                              "inputs": {
+                                "number_of_hits": null,
+                                "filter": 1,
+                                "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                "evalue": "1e-15",
+                                "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                              },
+                              "failures": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                        "causedBy": []
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }],
+                                "message": "Workflow failed"
+                              }],
+                              "end": "2019-10-14T14:59:51.838Z",
+                              "attempt": 1,
+                              "executionEvents": [{
+                                "startTime": "2019-10-14T14:58:57.746Z",
+                                "description": "SubWorkflowPreparingState",
+                                "endTime": "2019-10-14T14:58:57.750Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.746Z",
+                                "description": "WaitingForValueStore",
+                                "endTime": "2019-10-14T14:58:57.746Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.750Z",
+                                "description": "SubWorkflowRunningState",
+                                "endTime": "2019-10-14T14:59:51.838Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.745Z",
+                                "description": "SubWorkflowPendingState",
+                                "endTime": "2019-10-14T14:58:57.746Z"
+                              }],
+                              "start": "2019-10-14T14:58:57.745Z"
+                            }]
+                          },
+                          "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                          "id": "1d400c41-5554-4f24-b1de-40072f3d9846",
+                          "inputs": {
+                            "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"],
+                            "id_blast_database": {
+                              "number_of_hits": null,
+                              "reconcile_lca_or_random": null,
+                              "summary_taxon": null,
+                              "db_index_cdb": null,
+                              "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                              "max_informative_taxa_hits": null,
+                              "minimum_taxa_hits": null,
+                              "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                              "min_match_identity_pct": 95.0,
+                              "filter": 1,
+                              "report_style": null,
+                              "database_name": "vector",
+                              "evalue": "1e-15",
+                              "target_taxon_id": 9606,
+                              "min_match_length_bp": 25
+                            }
+                          },
+                          "status": "Failed",
+                          "parentWorkflowId": "51564ab2-e530-4be9-8f0c-c3c60b5c8ae2",
+                          "end": "2019-10-14T14:59:52.825Z",
+                          "start": "2019-10-14T14:58:53.668Z"
+                        },
+                        "shardIndex": 0,
+                        "inputs": {
+                          "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"],
+                          "id_blast_database": {
+                            "number_of_hits": null,
+                            "reconcile_lca_or_random": null,
+                            "summary_taxon": null,
+                            "db_index_cdb": null,
+                            "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                            "max_informative_taxa_hits": null,
+                            "minimum_taxa_hits": null,
+                            "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                            "min_match_identity_pct": 95.0,
+                            "filter": 1,
+                            "report_style": null,
+                            "database_name": "vector",
+                            "evalue": "1e-15",
+                            "target_taxon_id": 9606,
+                            "min_match_length_bp": 25
+                          }
+                        },
+                        "failures": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                    "causedBy": []
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                    "causedBy": []
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                    "causedBy": []
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }],
+                            "message": "Workflow failed"
+                          }],
+                          "message": "Workflow failed"
+                        }],
+                        "end": "2019-10-14T14:59:52.825Z",
+                        "attempt": 1,
+                        "executionEvents": [{
+                          "startTime": "2019-10-14T14:58:53.668Z",
+                          "description": "SubWorkflowPreparingState",
+                          "endTime": "2019-10-14T14:58:53.674Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.674Z",
+                          "description": "SubWorkflowRunningState",
+                          "endTime": "2019-10-14T14:59:52.825Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.667Z",
+                          "description": "SubWorkflowPendingState",
+                          "endTime": "2019-10-14T14:58:53.667Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.667Z",
+                          "description": "WaitingForValueStore",
+                          "endTime": "2019-10-14T14:58:53.668Z"
+                        }],
+                        "start": "2019-10-14T14:58:53.667Z"
+                      }]
+                    },
+                    "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                    "id": "51564ab2-e530-4be9-8f0c-c3c60b5c8ae2",
+                    "inputs": {
+                      "read_sets": [["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                      "id_blast_database": {
+                        "number_of_hits": null,
+                        "reconcile_lca_or_random": null,
+                        "summary_taxon": null,
+                        "db_index_cdb": null,
+                        "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                        "max_informative_taxa_hits": null,
+                        "minimum_taxa_hits": null,
+                        "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                        "min_match_identity_pct": 95.0,
+                        "filter": 1,
+                        "report_style": null,
+                        "database_name": "vector",
+                        "evalue": "1e-15",
+                        "target_taxon_id": 9606,
+                        "min_match_length_bp": 25
+                      },
+                      "sample_name": "C836.BICR_18.2.chr22"
+                    },
+                    "status": "Failed",
+                    "parentWorkflowId": "f26876de-1857-4ad3-92bd-61df8d21da99",
+                    "end": "2019-10-14T14:59:53.847Z",
+                    "start": "2019-10-14T14:58:49.579Z"
+                  },
+                  "shardIndex": 0,
+                  "inputs": {
+                    "read_sets": [["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                    "id_blast_database": {
+                      "number_of_hits": null,
+                      "reconcile_lca_or_random": null,
+                      "summary_taxon": null,
+                      "db_index_cdb": null,
+                      "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                      "max_informative_taxa_hits": null,
+                      "minimum_taxa_hits": null,
+                      "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                      "min_match_identity_pct": 95.0,
+                      "filter": 1,
+                      "report_style": null,
+                      "database_name": "vector",
+                      "evalue": "1e-15",
+                      "target_taxon_id": 9606,
+                      "min_match_length_bp": 25
+                    },
+                    "sample_name": "C836.BICR_18.2.chr22"
+                  },
+                  "failures": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                                "causedBy": []
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }],
+                        "message": "Workflow failed"
+                      }],
+                      "message": "Workflow failed"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "end": "2019-10-14T14:59:53.847Z",
+                  "attempt": 1,
+                  "executionEvents": [{
+                    "startTime": "2019-10-14T14:58:49.584Z",
+                    "description": "SubWorkflowRunningState",
+                    "endTime": "2019-10-14T14:59:53.847Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.579Z",
+                    "description": "SubWorkflowPreparingState",
+                    "endTime": "2019-10-14T14:58:49.584Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.578Z",
+                    "description": "WaitingForValueStore",
+                    "endTime": "2019-10-14T14:58:49.579Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.578Z",
+                    "description": "SubWorkflowPendingState",
+                    "endTime": "2019-10-14T14:58:49.578Z"
+                  }],
+                  "start": "2019-10-14T14:58:49.578Z"
+                }, {
+                  "retryableFailure": false,
+                  "executionStatus": "Failed",
+                  "subWorkflowMetadata": {
+                    "workflowName": "contam_testing_assay_id",
+                    "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                    "calls": {
+                      "contam_testing_assay_id.contam_testing_set_id": [{
+                        "retryableFailure": false,
+                        "executionStatus": "Failed",
+                        "subWorkflowMetadata": {
+                          "workflowName": "contam_testing_set_id",
+                          "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                          "calls": {
+                            "contam_testing_set_id.contam_testing_set_id_by_volume": [{
+                              "retryableFailure": false,
+                              "executionStatus": "Failed",
+                              "subWorkflowMetadata": {
+                                "workflowName": "contam_testing_set_id_by_volume",
+                                "rootWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+                                "calls": {
+                                  "contam_testing_set_id_by_volume.id_blast": [{
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/execution/stdout",
+                                    "shardIndex": 0,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.1.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:48.247Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.862Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.863Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.211Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:48.247Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.082Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.211Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:48.247Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:48.247Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.863Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.082Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.863Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/execution/stdout",
+                                    "shardIndex": 1,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.10.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:43.836Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.860Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.119Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.860Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.119Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:43.836Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:43.836Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:43.836Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.860Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/execution/stdout",
+                                    "shardIndex": 2,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.2.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:45.689Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:45.689Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:45.689Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.859Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.082Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.110Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.082Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.110Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:45.689Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.859Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/execution/stdout",
+                                    "shardIndex": 3,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.3.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:45.147Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:45.147Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:45.147Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.082Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.082Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.170Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.170Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:45.147Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.862Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.862Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.862Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.862Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/execution/stdout",
+                                    "shardIndex": 4,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.4.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:43.808Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.176Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:43.808Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:43.808Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.859Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.176Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:43.808Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.859Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.858Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/execution/stdout",
+                                    "shardIndex": 5,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.5.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:53.219Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.862Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.082Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.141Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.861Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.862Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.141Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:53.219Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.082Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:53.219Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:53.219Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.861Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/execution/stdout",
+                                    "shardIndex": 6,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.6.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:39.867Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.860Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.861Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.197Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:39.867Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:39.867Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:39.867Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.082Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.197Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.861Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.082Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.861Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/execution/stdout",
+                                    "shardIndex": 7,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.7.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:43.096Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:43.096Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:43.096Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.218Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.218Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:43.096Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.858Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.858Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/execution/stdout",
+                                    "shardIndex": 8,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.8.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:40.468Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:02.133Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:40.468Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.081Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.858Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:40.468Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:40.468Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.081Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.133Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.858Z"
+                                  }, {
+                                    "retryableFailure": false,
+                                    "executionStatus": "Failed",
+                                    "stdout": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/execution/stdout",
+                                    "shardIndex": 9,
+                                    "runtimeAttributes": {
+                                      "docker": "elilillyco-omics-docker-lc.jfrog.io/qc/blast:2.2.26",
+                                      "failOnStderr": "false",
+                                      "maxRetries": "0",
+                                      "continueOnReturnCode": "0"
+                                    },
+                                    "callCaching": {
+                                      "allowResultReuse": false,
+                                      "effectiveCallCachingMode": "CallCachingOff"
+                                    },
+                                    "inputs": {
+                                      "number_of_hits": null,
+                                      "default_evalue": "1e-12",
+                                      "default_number_of_hits": 10,
+                                      "filter": 0,
+                                      "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                      "default_filter": 0,
+                                      "query_file": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9",
+                                      "evalue": "1e-12",
+                                      "output_filename": "C836.BICR_18.2.chr22.fq.gz.9.ngs_adaptors.tar.gz.blast_report.txt"
+                                    },
+                                    "failures": [{
+                                      "causedBy": [{
+                                        "causedBy": [{
+                                          "causedBy": [{
+                                            "causedBy": [],
+                                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                          }],
+                                          "message": "Error(s)"
+                                        }],
+                                        "message": "Failed command instantiation"
+                                      }],
+                                      "message": "java.lang.Exception: Failed command instantiation"
+                                    }],
+                                    "backend": "Local",
+                                    "end": "2019-10-14T14:59:38.187Z",
+                                    "stderr": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/execution/stderr",
+                                    "callRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9",
+                                    "attempt": 1,
+                                    "executionEvents": [{
+                                      "startTime": "2019-10-14T14:59:38.187Z",
+                                      "description": "UpdatingJobStore",
+                                      "endTime": "2019-10-14T14:59:38.187Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.080Z",
+                                      "description": "WaitingForValueStore",
+                                      "endTime": "2019-10-14T14:59:02.086Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.858Z",
+                                      "description": "RequestingExecutionToken",
+                                      "endTime": "2019-10-14T14:59:02.080Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.086Z",
+                                      "description": "PreparingJob",
+                                      "endTime": "2019-10-14T14:59:02.186Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:02.186Z",
+                                      "description": "RunningJob",
+                                      "endTime": "2019-10-14T14:59:38.187Z"
+                                    }, {
+                                      "startTime": "2019-10-14T14:59:01.857Z",
+                                      "description": "Pending",
+                                      "endTime": "2019-10-14T14:59:01.858Z"
+                                    }],
+                                    "start": "2019-10-14T14:59:01.857Z"
+                                  }]
+                                },
+                                "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                                "id": "b647c0d6-f125-4b51-a48e-8023002c01f7",
+                                "inputs": {
+                                  "number_of_hits": null,
+                                  "filter": 0,
+                                  "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                  "evalue": "1e-12",
+                                  "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                                },
+                                "status": "Failed",
+                                "parentWorkflowId": "28db92b2-e307-413a-951c-ecdf4223844c",
+                                "end": "2019-10-14T14:59:53.876Z",
+                                "start": "2019-10-14T14:58:57.747Z"
+                              },
+                              "shardIndex": 0,
+                              "inputs": {
+                                "number_of_hits": null,
+                                "filter": 0,
+                                "blast_database_archive": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                "evalue": "1e-12",
+                                "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]
+                              },
+                              "failures": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }, {
+                                  "causedBy": [{
+                                    "causedBy": [{
+                                      "causedBy": [{
+                                        "causedBy": [],
+                                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                      }],
+                                      "message": "Error(s)"
+                                    }],
+                                    "message": "Failed command instantiation"
+                                  }],
+                                  "message": "java.lang.Exception: Failed command instantiation"
+                                }],
+                                "message": "Workflow failed"
+                              }],
+                              "end": "2019-10-14T14:59:53.876Z",
+                              "attempt": 1,
+                              "executionEvents": [{
+                                "startTime": "2019-10-14T14:58:57.747Z",
+                                "description": "SubWorkflowPreparingState",
+                                "endTime": "2019-10-14T14:58:57.750Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.746Z",
+                                "description": "WaitingForValueStore",
+                                "endTime": "2019-10-14T14:58:57.747Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.750Z",
+                                "description": "SubWorkflowRunningState",
+                                "endTime": "2019-10-14T14:59:53.876Z"
+                              }, {
+                                "startTime": "2019-10-14T14:58:57.746Z",
+                                "description": "SubWorkflowPendingState",
+                                "endTime": "2019-10-14T14:58:57.746Z"
+                              }],
+                              "start": "2019-10-14T14:58:57.745Z"
+                            }]
+                          },
+                          "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                          "id": "28db92b2-e307-413a-951c-ecdf4223844c",
+                          "inputs": {
+                            "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"],
+                            "id_blast_database": {
+                              "number_of_hits": null,
+                              "reconcile_lca_or_random": null,
+                              "summary_taxon": null,
+                              "db_index_cdb": null,
+                              "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                              "max_informative_taxa_hits": null,
+                              "minimum_taxa_hits": null,
+                              "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                              "min_match_identity_pct": 99.0,
+                              "filter": 0,
+                              "report_style": null,
+                              "database_name": "ngs_adaptor",
+                              "evalue": "1e-12",
+                              "target_taxon_id": 9606,
+                              "min_match_length_bp": 35
+                            }
+                          },
+                          "status": "Failed",
+                          "parentWorkflowId": "357a9678-6532-4077-a5ed-ab31a2fcad1d",
+                          "end": "2019-10-14T14:59:54.867Z",
+                          "start": "2019-10-14T14:58:53.668Z"
+                        },
+                        "shardIndex": 0,
+                        "inputs": {
+                          "fa_files": ["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"],
+                          "id_blast_database": {
+                            "number_of_hits": null,
+                            "reconcile_lca_or_random": null,
+                            "summary_taxon": null,
+                            "db_index_cdb": null,
+                            "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                            "max_informative_taxa_hits": null,
+                            "minimum_taxa_hits": null,
+                            "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                            "min_match_identity_pct": 99.0,
+                            "filter": 0,
+                            "report_style": null,
+                            "database_name": "ngs_adaptor",
+                            "evalue": "1e-12",
+                            "target_taxon_id": 9606,
+                            "min_match_length_bp": 35
+                          }
+                        },
+                        "failures": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                                    "causedBy": []
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }, {
+                              "causedBy": [{
+                                "causedBy": [{
+                                  "causedBy": [{
+                                    "causedBy": [],
+                                    "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                                  }],
+                                  "message": "Error(s)"
+                                }],
+                                "message": "Failed command instantiation"
+                              }],
+                              "message": "java.lang.Exception: Failed command instantiation"
+                            }],
+                            "message": "Workflow failed"
+                          }],
+                          "message": "Workflow failed"
+                        }],
+                        "end": "2019-10-14T14:59:54.867Z",
+                        "attempt": 1,
+                        "executionEvents": [{
+                          "startTime": "2019-10-14T14:58:53.667Z",
+                          "description": "SubWorkflowPendingState",
+                          "endTime": "2019-10-14T14:58:53.667Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.668Z",
+                          "description": "SubWorkflowPreparingState",
+                          "endTime": "2019-10-14T14:58:53.674Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.667Z",
+                          "description": "WaitingForValueStore",
+                          "endTime": "2019-10-14T14:58:53.668Z"
+                        }, {
+                          "startTime": "2019-10-14T14:58:53.674Z",
+                          "description": "SubWorkflowRunningState",
+                          "endTime": "2019-10-14T14:59:54.867Z"
+                        }],
+                        "start": "2019-10-14T14:58:53.667Z"
+                      }]
+                    },
+                    "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+                    "id": "357a9678-6532-4077-a5ed-ab31a2fcad1d",
+                    "inputs": {
+                      "read_sets": [["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                      "id_blast_database": {
+                        "number_of_hits": null,
+                        "reconcile_lca_or_random": null,
+                        "summary_taxon": null,
+                        "db_index_cdb": null,
+                        "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                        "max_informative_taxa_hits": null,
+                        "minimum_taxa_hits": null,
+                        "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                        "min_match_identity_pct": 99.0,
+                        "filter": 0,
+                        "report_style": null,
+                        "database_name": "ngs_adaptor",
+                        "evalue": "1e-12",
+                        "target_taxon_id": 9606,
+                        "min_match_length_bp": 35
+                      },
+                      "sample_name": "C836.BICR_18.2.chr22"
+                    },
+                    "status": "Failed",
+                    "parentWorkflowId": "f26876de-1857-4ad3-92bd-61df8d21da99",
+                    "end": "2019-10-14T14:59:55.888Z",
+                    "start": "2019-10-14T14:58:49.579Z"
+                  },
+                  "shardIndex": 1,
+                  "inputs": {
+                    "read_sets": [["/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.1", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.10", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.2", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.3", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.4", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.5", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.6", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.7", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.8", "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-fetch/shard-0/multi_lane_fetch/d89a7623-7e6d-4085-a1bb-7a4c897056ab/call-fastq_fetch/shard-0/execution/glob-e25084b50488a194bf448e4bd1f0d21d/C836.BICR_18.2.chr22.fq.gz.9"]],
+                    "id_blast_database": {
+                      "number_of_hits": null,
+                      "reconcile_lca_or_random": null,
+                      "summary_taxon": null,
+                      "db_index_cdb": null,
+                      "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                      "max_informative_taxa_hits": null,
+                      "minimum_taxa_hits": null,
+                      "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                      "min_match_identity_pct": 99.0,
+                      "filter": 0,
+                      "report_style": null,
+                      "database_name": "ngs_adaptor",
+                      "evalue": "1e-12",
+                      "target_taxon_id": 9606,
+                      "min_match_length_bp": 35
+                    },
+                    "sample_name": "C836.BICR_18.2.chr22"
+                  },
+                  "failures": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }, {
+                          "causedBy": [{
+                            "causedBy": [{
+                              "causedBy": [{
+                                "causedBy": [],
+                                "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                              }],
+                              "message": "Error(s)"
+                            }],
+                            "message": "Failed command instantiation"
+                          }],
+                          "message": "java.lang.Exception: Failed command instantiation"
+                        }],
+                        "message": "Workflow failed"
+                      }],
+                      "message": "Workflow failed"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "end": "2019-10-14T14:59:55.888Z",
+                  "attempt": 1,
+                  "executionEvents": [{
+                    "startTime": "2019-10-14T14:58:49.579Z",
+                    "description": "SubWorkflowPreparingState",
+                    "endTime": "2019-10-14T14:58:49.585Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.578Z",
+                    "description": "SubWorkflowPendingState",
+                    "endTime": "2019-10-14T14:58:49.578Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.578Z",
+                    "description": "WaitingForValueStore",
+                    "endTime": "2019-10-14T14:58:49.579Z"
+                  }, {
+                    "startTime": "2019-10-14T14:58:49.585Z",
+                    "description": "SubWorkflowRunningState",
+                    "endTime": "2019-10-14T14:59:55.888Z"
+                  }],
+                  "start": "2019-10-14T14:58:49.577Z"
+                }]
+              },
+              "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+              "id": "f26876de-1857-4ad3-92bd-61df8d21da99",
+              "inputs": {
+                "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_prefix": null,
+                "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null,
+                "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_prefix": null,
+                "org_blast_databases": [{
+                  "number_of_hits": 10,
+                  "reconcile_lca_or_random": "lca",
+                  "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                  "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                  "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                  "max_informative_taxa_hits": 5,
+                  "minimum_taxa_hits": 2,
+                  "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                  "filter": 1,
+                  "database_name": "standard_org",
+                  "evalue": "1e-8",
+                  "target_taxon_id": 9606,
+                  "reporting_cutoff_percentage": null
+                }],
+                "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+                "contam_testing_sample.count_blast_matches_non_rrna.cdb_index_mapping_taxon_ids_to_paths": null,
+                "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_prefix": null,
+                "create_homopolymer_report": false,
+                "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+                "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+                "number_of_sets": 10,
+                "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+                "suppress_reads_homopolymer_cutoff": 0.0,
+                "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+                "sample_data": {
+                  "C836.BICR_18.2.chr22.Assay": {
+                    "right": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                    "left": ["/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz"]
+                  }
+                },
+                "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+                "number_of_reads": 100000,
+                "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+                "contam_testing_sample.org_report.read_length": null,
+                "read_name_format": 0,
+                "sample_name": "C836.BICR_18.2.chr22",
+                "id_blast_databases": [{
+                  "number_of_hits": null,
+                  "reconcile_lca_or_random": null,
+                  "summary_taxon": null,
+                  "db_index_cdb": null,
+                  "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                  "max_informative_taxa_hits": null,
+                  "minimum_taxa_hits": null,
+                  "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                  "min_match_identity_pct": 95.0,
+                  "filter": 1,
+                  "report_style": null,
+                  "database_name": "vector",
+                  "evalue": "1e-15",
+                  "target_taxon_id": 9606,
+                  "min_match_length_bp": 25
+                }, {
+                  "number_of_hits": null,
+                  "reconcile_lca_or_random": null,
+                  "summary_taxon": null,
+                  "db_index_cdb": null,
+                  "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                  "max_informative_taxa_hits": null,
+                  "minimum_taxa_hits": null,
+                  "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                  "min_match_identity_pct": 99.0,
+                  "filter": 0,
+                  "report_style": null,
+                  "database_name": "ngs_adaptor",
+                  "evalue": "1e-12",
+                  "target_taxon_id": 9606,
+                  "min_match_length_bp": 35
+                }],
+                "contam_testing_sample.count_blast_matches_non_rrna.cdb_index_sequence_ids_into_taxon_ids": null,
+                "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+                "fq_fa_or_bam": "fq",
+                "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_read_details_report": null
+              },
+              "status": "Failed",
+              "parentWorkflowId": "7a98dbee-ef74-4286-bbcc-50af9ec5be4e",
+              "end": "2019-10-14T14:59:56.897Z",
+              "start": "2019-10-14T14:58:26.108Z"
+            },
+            "shardIndex": 0,
+            "inputs": {
+              "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_prefix": null,
+              "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null,
+              "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_prefix": null,
+              "org_blast_databases": [{
+                "number_of_hits": 10,
+                "reconcile_lca_or_random": "lca",
+                "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+                "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+                "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                "max_informative_taxa_hits": 5,
+                "minimum_taxa_hits": 2,
+                "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+                "filter": 1,
+                "database_name": "standard_org",
+                "evalue": "1e-8",
+                "target_taxon_id": 9606,
+                "reporting_cutoff_percentage": null
+              }],
+              "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+              "contam_testing_sample.count_blast_matches_non_rrna.cdb_index_mapping_taxon_ids_to_paths": null,
+              "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_prefix": null,
+              "create_homopolymer_report": false,
+              "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+              "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_reads_filename": null,
+              "number_of_sets": 10,
+              "contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_read_details_report": null,
+              "suppress_reads_homopolymer_cutoff": 0.0,
+              "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+              "sample_data": {
+                "C836.BICR_18.2.chr22.Assay": {
+                  "right": "/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz",
+                  "left": ["/Users/c252930/omics/C836.BICR_18.2.chr22.fq.gz"]
+                }
+              },
+              "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.read_details_filename": null,
+              "number_of_reads": 100000,
+              "contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+              "contam_testing_sample.org_report.read_length": null,
+              "read_name_format": 0,
+              "sample_name": "C836.BICR_18.2.chr22",
+              "id_blast_databases": [{
+                "number_of_hits": null,
+                "reconcile_lca_or_random": null,
+                "summary_taxon": null,
+                "db_index_cdb": null,
+                "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                "max_informative_taxa_hits": null,
+                "minimum_taxa_hits": null,
+                "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+                "min_match_identity_pct": 95.0,
+                "filter": 1,
+                "report_style": null,
+                "database_name": "vector",
+                "evalue": "1e-15",
+                "target_taxon_id": 9606,
+                "min_match_length_bp": 25
+              }, {
+                "number_of_hits": null,
+                "reconcile_lca_or_random": null,
+                "summary_taxon": null,
+                "db_index_cdb": null,
+                "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+                "max_informative_taxa_hits": null,
+                "minimum_taxa_hits": null,
+                "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+                "min_match_identity_pct": 99.0,
+                "filter": 0,
+                "report_style": null,
+                "database_name": "ngs_adaptor",
+                "evalue": "1e-12",
+                "target_taxon_id": 9606,
+                "min_match_length_bp": 35
+              }],
+              "contam_testing_sample.count_blast_matches_non_rrna.cdb_index_sequence_ids_into_taxon_ids": null,
+              "contam_testing_sample.contam_testing_assay_org.contam_testing_assay_org.contam_testing_set_org.contam_testing_set_org.contam_testing_set_org_by_volume.contam_testing_set_org_by_volume.org_sum.taxon_counts_by_hit_alignments_filename": null,
+              "fq_fa_or_bam": "fq",
+              "contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_read_details_report": null
+            },
+            "failures": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "message": "Workflow failed"
+                }],
+                "message": "Workflow failed"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "message": "Workflow failed"
+                }],
+                "message": "Workflow failed"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                            "causedBy": []
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }, {
+                      "causedBy": [{
+                        "causedBy": [{
+                          "causedBy": [{
+                            "causedBy": [],
+                            "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                          }],
+                          "message": "Error(s)"
+                        }],
+                        "message": "Failed command instantiation"
+                      }],
+                      "message": "java.lang.Exception: Failed command instantiation"
+                    }],
+                    "message": "Workflow failed"
+                  }],
+                  "message": "Workflow failed"
+                }],
+                "message": "Workflow failed"
+              }],
+              "message": "Workflow failed"
+            }],
+            "end": "2019-10-14T14:59:56.897Z",
+            "attempt": 1,
+            "executionEvents": [{
+              "startTime": "2019-10-14T14:58:26.120Z",
+              "description": "SubWorkflowRunningState",
+              "endTime": "2019-10-14T14:59:56.897Z"
+            }, {
+              "startTime": "2019-10-14T14:58:26.108Z",
+              "description": "SubWorkflowPreparingState",
+              "endTime": "2019-10-14T14:58:26.120Z"
+            }, {
+              "startTime": "2019-10-14T14:58:26.102Z",
+              "description": "SubWorkflowPendingState",
+              "endTime": "2019-10-14T14:58:26.104Z"
+            }, {
+              "startTime": "2019-10-14T14:58:26.104Z",
+              "description": "WaitingForValueStore",
+              "endTime": "2019-10-14T14:58:26.108Z"
+            }],
+            "start": "2019-10-14T14:58:26.104Z"
+          }]
+        },
+        "id": "7a98dbee-ef74-4286-bbcc-50af9ec5be4e",
+        "inputs": {
+          "contam_testing.contam_testing_sample.contam_testing_sample.count_blast_matches_non_rrna.cdb_index_sequence_ids_into_taxon_ids": null,
+          "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+          "output_prefix": "20190604164608",
+          "org_blast_databases": [{
+            "number_of_hits": 10,
+            "reconcile_lca_or_random": "lca",
+            "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+            "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+            "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+            "max_informative_taxa_hits": 5,
+            "minimum_taxa_hits": 2,
+            "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+            "filter": 1,
+            "database_name": "standard_org",
+            "evalue": "1e-8",
+            "target_taxon_id": 9606,
+            "reporting_cutoff_percentage": null
+          }],
+          "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+          "use_total_retrieval_sequences": null,
+          "suppress_reads_homopolymer_cutoff": null,
+          "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+          "taxon_names_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/term_data.cdb",
+          "number_of_reads": 100000,
+          "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null
+        },
+        "status": "Failed",
+        "parentWorkflowId": "86a1c036-99f1-4137-b590-ba04460b3037",
+        "end": "2019-10-14T14:59:57.907Z",
+        "start": "2019-10-14T14:58:20.932Z"
+      },
+      "shardIndex": -1,
+      "inputs": {
+        "contam_testing.contam_testing_sample.contam_testing_sample.count_blast_matches_non_rrna.cdb_index_sequence_ids_into_taxon_ids": null,
+        "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_homopolymer_report": null,
+        "output_prefix": "20190604164608",
+        "org_blast_databases": [{
+          "number_of_hits": 10,
+          "reconcile_lca_or_random": "lca",
+          "summary_taxon": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["9443", "Primates"], ["9989", "Rodents"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["314295", "Apes"]],
+          "db_index_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db_info.cdb",
+          "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+          "max_informative_taxa_hits": 5,
+          "minimum_taxa_hits": 2,
+          "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"],
+          "filter": 1,
+          "database_name": "standard_org",
+          "evalue": "1e-8",
+          "target_taxon_id": 9606,
+          "reporting_cutoff_percentage": null
+        }],
+        "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_homopolymer_report": null,
+        "use_total_retrieval_sequences": null,
+        "suppress_reads_homopolymer_cutoff": null,
+        "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_homopolymer_report": null,
+        "taxon_names_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/term_data.cdb",
+        "number_of_reads": 100000,
+        "contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_read_details_report": null
+      },
+      "failures": [{
+        "causedBy": [{
+          "causedBy": [{
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }],
+                "message": "Workflow failed"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }, {
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                        "causedBy": []
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }],
+                "message": "Workflow failed"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }, {
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }, {
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [{
+                        "causedBy": [],
+                        "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                      }],
+                      "message": "Error(s)"
+                    }],
+                    "message": "Failed command instantiation"
+                  }],
+                  "message": "java.lang.Exception: Failed command instantiation"
+                }],
+                "message": "Workflow failed"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }],
+          "message": "Workflow failed"
+        }],
+        "message": "Workflow failed"
+      }],
+      "end": "2019-10-14T14:59:57.907Z",
+      "attempt": 1,
+      "executionEvents": [{
+        "startTime": "2019-10-14T14:58:20.932Z",
+        "description": "SubWorkflowPreparingState",
+        "endTime": "2019-10-14T14:58:20.958Z"
+      }, {
+        "startTime": "2019-10-14T14:58:20.958Z",
+        "description": "SubWorkflowRunningState",
+        "endTime": "2019-10-14T14:59:57.907Z"
+      }, {
+        "startTime": "2019-10-14T14:58:20.924Z",
+        "description": "SubWorkflowPendingState",
+        "endTime": "2019-10-14T14:58:20.929Z"
+      }, {
+        "startTime": "2019-10-14T14:58:20.929Z",
+        "description": "WaitingForValueStore",
+        "endTime": "2019-10-14T14:58:20.932Z"
+      }],
+      "start": "2019-10-14T14:58:20.922Z"
+    }]
+  },
+  "outputs": {
+
+  },
+  "workflowRoot": "/Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037",
+  "actualWorkflowLanguage": "WDL",
+  "id": "86a1c036-99f1-4137-b590-ba04460b3037",
+  "inputs": {
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_prefix": null,
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fastq_fetch.output_prefix": null,
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.count_blast_matches_non_rrna.cdb_index_sequence_ids_into_taxon_ids": null,
+    "create_homopolymer_report": null,
+    "taxon_paths_cdb": "/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/taxonomy_cdb/current/path_data.cdb",
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.fasta_fetch.output_read_details_report": null,
+    "suppress_reads_homopolymer_cutoff": null,
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.count_blast_matches_non_rrna.cdb_index_mapping_taxon_ids_to_paths": null,
+    "id_blast_databases": [{
+      "number_of_hits": null,
+      "reconcile_lca_or_random": null,
+      "summary_taxon": null,
+      "db_index_cdb": null,
+      "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+      "max_informative_taxa_hits": null,
+      "minimum_taxa_hits": null,
+      "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"],
+      "min_match_identity_pct": 95.0,
+      "filter": 1,
+      "report_style": null,
+      "database_name": "vector",
+      "evalue": "1e-15",
+      "target_taxon_id": 9606,
+      "min_match_length_bp": 25
+    }, {
+      "number_of_hits": null,
+      "reconcile_lca_or_random": null,
+      "summary_taxon": null,
+      "db_index_cdb": null,
+      "friendly_names": [["2", "Eubacteria"], ["2157", "Archaea"], ["4751", "Fungi"], ["6231", "Nematodes"], ["6447", "Molusks"], ["6656", "Arthropods"], ["9263", "Marsupials"], ["9443", "Primates"], ["9539", "Macaques"], ["9541", "Cyno (M. fascicularis)"], ["9606", "Human"], ["9989", "Rodents"], ["10029", "CHO"], ["10090", "Mouse"], ["10116", "Rat"], ["10239", "Viruses"], ["33090", "Green Plants"], ["33208", "Animals"], ["40674", "Mammals"], ["50557", "Insects"], ["314295", "Apes"]],
+      "max_informative_taxa_hits": null,
+      "minimum_taxa_hits": null,
+      "blast_database_volumes": ["/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"],
+      "min_match_identity_pct": 99.0,
+      "filter": 0,
+      "report_style": null,
+      "database_name": "ngs_adaptor",
+      "evalue": "1e-12",
+      "target_taxon_id": 9606,
+      "min_match_length_bp": 35
+    }],
+    "test_contam_testing.contam_testing.contam_testing.contam_testing_sample.contam_testing_sample.fetch.multi_lane_fetch.bam_fetch.output_homopolymer_report": null
+  },
+  "labels": {
+    "cromwell-workflow-id": "cromwell-86a1c036-99f1-4137-b590-ba04460b3037"
+  },
+  "submission": "2019-10-14T14:58:17.114Z",
+  "status": "Failed",
+  "failures": [{
+    "causedBy": [{
+      "causedBy": [{
+        "causedBy": [{
+          "causedBy": [{
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-3/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-0/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-8/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-7/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz",
+                      "causedBy": []
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-1/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-4/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-5/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-2/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-9/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_org/shard-0/contam_testing_assay_org/7c70402f-acab-4840-aa94-9852834aef3f/call-contam_testing_set_org/shard-0/contam_testing_set_org/d067c866-3be8-4db2-92e5-63d62f371751/call-contam_testing_set_org_by_volume/shard-0/contam_testing_set_org_by_volume/563012ef-e593-42dc-9de0-f0a682ce23e3/call-org_blast/shard-6/inputs/-527633952/rep_db.fa.02.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/RepDB/current/rep_db.fa.02.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }],
+          "message": "Workflow failed"
+        }, {
+          "causedBy": [{
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-9/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-8/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-7/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-4/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-2/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-1/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-6/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-5/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-3/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-0/contam_testing_assay_id/51564ab2-e530-4be9-8f0c-c3c60b5c8ae2/call-contam_testing_set_id/shard-0/contam_testing_set_id/1d400c41-5554-4f24-b1de-40072f3d9846/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/0110679b-ed53-44e0-b7b5-ba1ac61c9282/call-id_blast/shard-0/inputs/-282936342/synthetic.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/synthetic/current/synthetic.tar.gz",
+                      "causedBy": []
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }],
+          "message": "Workflow failed"
+        }, {
+          "causedBy": [{
+            "causedBy": [{
+              "causedBy": [{
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-9/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-8/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-7/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-4/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-2/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz",
+                      "causedBy": []
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-1/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-6/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-5/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-3/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }, {
+                "causedBy": [{
+                  "causedBy": [{
+                    "causedBy": [{
+                      "causedBy": [],
+                      "message": ":\nCould not localize /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz -> /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz:\n\t/Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz doesn't exist\n\tFile not found /Users/c252930/omics/contam/data47/cromwell-executions/test_contam_testing/86a1c036-99f1-4137-b590-ba04460b3037/call-contam_testing/contam_testing/7a98dbee-ef74-4286-bbcc-50af9ec5be4e/call-contam_testing_sample/shard-0/contam_testing_sample/f26876de-1857-4ad3-92bd-61df8d21da99/call-contam_testing_assay_id/shard-1/contam_testing_assay_id/357a9678-6532-4077-a5ed-ab31a2fcad1d/call-contam_testing_set_id/shard-0/contam_testing_set_id/28db92b2-e307-413a-951c-ecdf4223844c/call-contam_testing_set_id_by_volume/shard-0/contam_testing_set_id_by_volume/b647c0d6-f125-4b51-a48e-8023002c01f7/call-id_blast/shard-0/inputs/-1427217502/ngs_adaptors.tar.gz -> /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz\n\tFile not found /Volumes/lrlhps/genomics/prod/genome_projects/resources/sources/wdl_rnaseq_data/blast_databases/ngs_adaptors/current/ngs_adaptors.tar.gz"
+                    }],
+                    "message": "Error(s)"
+                  }],
+                  "message": "Failed command instantiation"
+                }],
+                "message": "java.lang.Exception: Failed command instantiation"
+              }],
+              "message": "Workflow failed"
+            }],
+            "message": "Workflow failed"
+          }],
+          "message": "Workflow failed"
+        }],
+        "message": "Workflow failed"
+      }],
+      "message": "Workflow failed"
+    }],
+    "message": "Workflow failed"
+  }],
+  "end": "2019-10-14T14:59:58.853Z",
+  "start": "2019-10-14T14:58:17.218Z"
+}

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,40 @@
+import textwrap
+
+from pytest_wdl.executors import ExecutionFailedError
+
+
+def test_execution_failed_error():
+    try:
+        raise ExecutionFailedError(
+            executor="foo",
+            target="target",
+            status="Failed",
+            inputs={
+                "a": 1,
+                "b": "bar"
+            },
+            executor_stdout="dis happen",
+            executor_stderr="dis an err\noopsy",
+            failed_task="baz",
+            failed_task_exit_status=1,
+            failed_task_stdout="oh oh\nsomeone set us up the bomb",
+            failed_task_stderr="beep boop beep\nI am except"
+        )
+    except ExecutionFailedError as err:
+        assert str(err) == textwrap.dedent(f"""
+        foo failed with status Failed while running task baz of target:
+            inputs:
+                {{'a': 1, 'b': 'bar'}}
+            executor_stdout:
+                dis happen
+            executor_stderr:
+                dis an err
+                oopsy
+            failed_task_exit_status: 1
+            failed_task_stdout:
+                oh oh
+                someone set us up the bomb
+            failed_task_stderr:
+                beep boop beep
+                I am except
+        """)

--- a/tests/test_localizers.py
+++ b/tests/test_localizers.py
@@ -88,22 +88,22 @@ def test_url_localizer():
         UrlLocalizer(bad_url, UserConfiguration(None, cache_dir=d)).localize(foo)
 
 
-@pytest.mark.skipif(no_internet, reason="no internet available")
-def test_url_localizer_corrupt_file():
-    good_url = GOOD_URL
-    with tempdir() as d:
-        foo = d / "foo"
-        # The localizer should detect that the file already exists, but that the
-        # digests don't match and overwrite it
-        with open(foo, "wt") as out:
-            out.write("blahblahblah")
-        UrlLocalizer(
-            good_url,
-            UserConfiguration(None, cache_dir=d),
-            digests={"md5": "acbd18db4cc2f85cedef654fccc4a4d8"}
-        ).localize(foo)
-        with open(foo, "rt") as inp:
-            assert inp.read() == "foo"
+# @pytest.mark.skipif(no_internet, reason="no internet available")
+# def test_url_localizer_corrupt_file():
+#     good_url = GOOD_URL
+#     with tempdir() as d:
+#         foo = d / "foo"
+#         # The localizer should detect that the file already exists, but that the
+#         # digests don't match and overwrite it
+#         with open(foo, "wt") as out:
+#             out.write("blahblahblah")
+#         UrlLocalizer(
+#             good_url,
+#             UserConfiguration(None, cache_dir=d),
+#             digests={"md5": "acbd18db4cc2f85cedef654fccc4a4d8"}
+#         ).localize(foo)
+#         with open(foo, "rt") as inp:
+#             assert inp.read() == "foo"
 
 
 def test_url_localizer_add_headers():

--- a/tests/test_localizers.py
+++ b/tests/test_localizers.py
@@ -88,6 +88,24 @@ def test_url_localizer():
         UrlLocalizer(bad_url, UserConfiguration(None, cache_dir=d)).localize(foo)
 
 
+@pytest.mark.skipif(no_internet, reason="no internet available")
+def test_url_localizer_corrupt_file():
+    good_url = GOOD_URL
+    with tempdir() as d:
+        foo = d / "foo"
+        # The localizer should detect that the file already exists, but that the
+        # digests don't match and overwrite it
+        with open(foo, "wt") as out:
+            out.write("blahblahblah")
+        UrlLocalizer(
+            good_url,
+            UserConfiguration(None, cache_dir=d),
+            digests={"md5": "acbd18db4cc2f85cedef654fccc4a4d8"}
+        ).localize(foo)
+        with open(foo, "rt") as inp:
+            assert inp.read() == "foo"
+
+
 def test_url_localizer_add_headers():
     with setenv({
        "FOO": "bar"

--- a/tests/test_url_schemes.py
+++ b/tests/test_url_schemes.py
@@ -15,6 +15,7 @@ try:
     # test whether dxpy is installed and the user is logged in
     import dxpy
     assert dxpy.SECURITY_CONTEXT
+    assert dxpy.whoami()
     no_dx = False
 except:
     no_dx = True


### PR DESCRIPTION
Fix for #75 

Also refactoring in preparation to address #70, and support for files in datadirs that aren't defined in test_data.json.