### PR TITLE
Feat/86 no tests dir

### DIFF
--- a/pytest_wdl/fixtures.py
+++ b/pytest_wdl/fixtures.py
@@ -106,11 +106,20 @@ def workflow_data_descriptor_file(request: FixtureRequest) -> Union[str, Path]:
     Args:
         request: A FixtureRequest object
     """
-    tests = find_project_path("tests", start=Path(request.fspath.dirpath()))
+    path = Path(request.fspath.dirpath())
+
+    # Look in tests/ folder first
+    tests = find_project_path("tests", start=path)
     if tests:
         test_data = tests / DEFAULT_TEST_DATA_FILE
         if test_data.exists():
             return test_data
+
+    # Next look in the current directory
+    test_data = path / DEFAULT_TEST_DATA_FILE
+    if test_data.exists():
+        return test_data
+
     raise FileNotFoundError(f"Could not find {DEFAULT_TEST_DATA_FILE} file")  # TODO: test this
 
 

--- a/pytest_wdl/fixtures.py
+++ b/pytest_wdl/fixtures.py
@@ -108,17 +108,17 @@ def workflow_data_descriptor_file(request: FixtureRequest) -> Union[str, Path]:
     """
     path = Path(request.fspath.dirpath())
 
-    # Look in tests/ folder first
+    # First look in the current directory
+    test_data = path / DEFAULT_TEST_DATA_FILE
+    if test_data.exists():
+        return test_data
+
+    # Next look in tests/ folder first
     tests = find_project_path("tests", start=path)
     if tests:
         test_data = tests / DEFAULT_TEST_DATA_FILE
         if test_data.exists():
             return test_data
-
-    # Next look in the current directory
-    test_data = path / DEFAULT_TEST_DATA_FILE
-    if test_data.exists():
-        return test_data
 
     raise FileNotFoundError(f"Could not find {DEFAULT_TEST_DATA_FILE} file")  # TODO: test this
 

--- a/pytest_wdl/fixtures.py
+++ b/pytest_wdl/fixtures.py
@@ -106,21 +106,12 @@ def workflow_data_descriptor_file(request: FixtureRequest) -> Union[str, Path]:
     Args:
         request: A FixtureRequest object
     """
-    path = Path(request.fspath.dirpath())
-
-    # First look in the current directory
-    test_data = path / DEFAULT_TEST_DATA_FILE
-    if test_data.exists():
-        return test_data
-
-    # Next look in tests/ folder first
-    tests = find_project_path("tests", start=path)
-    if tests:
-        test_data = tests / DEFAULT_TEST_DATA_FILE
-        if test_data.exists():
-            return test_data
-
-    raise FileNotFoundError(f"Could not find {DEFAULT_TEST_DATA_FILE} file")  # TODO: test this
+    return find_project_path(
+        Path(DEFAULT_TEST_DATA_FILE),
+        Path("tests") / DEFAULT_TEST_DATA_FILE,
+        start=Path(request.fspath.dirpath()),
+        assert_exists=True
+    )
 
 
 def workflow_data_descriptors(

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -108,7 +108,7 @@ def test_task(workflow_data, workflow_runner, executor):
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("executor", ["miniwdl"]) #EXECUTORS.keys())
+@pytest.mark.parametrize("executor", EXECUTORS.keys())
 def test_execution_failure(workflow_data, workflow_runner, executor):
     inputs = {
         "in_txt": workflow_data["in_txt"],

--- a/tests/test_workflow_flat/README.md
+++ b/tests/test_workflow_flat/README.md
@@ -1,0 +1,5 @@
+# Test Workflow
+
+This reproduces an alternate project setup with all of the files (including test files) stored in the same directory. The test data are stored remotely as well which will test localization of the data for the workflow.
+
+This also introduces WDL 1.0.

--- a/tests/test_workflow_flat/test_data.json
+++ b/tests/test_workflow_flat/test_data.json
@@ -1,0 +1,6 @@
+{
+  "test_file": {
+    "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/master/README.md",
+    "path": "pytest_wdl_readme.md"
+  }
+}

--- a/tests/test_workflow_flat/test_workflow.py
+++ b/tests/test_workflow_flat/test_workflow.py
@@ -1,0 +1,23 @@
+#! /usr/bin/env python
+
+"""Test hello_world parent workflow"""
+import pytest
+
+
+@pytest.mark.integration
+def test_hello_world_parent_workflow(workflow_data, workflow_runner):
+    """Test the hello_world parent workflow with fixed inputs and outputs."""
+    inputs = {
+        "input_files": [
+            workflow_data["test_file"],
+            workflow_data["test_file"],
+        ]
+    }
+    expected = {
+        "single_file": workflow_data["test_file"]
+    }
+    workflow_runner(
+        "workflow.wdl",
+        inputs,
+        expected
+    )

--- a/tests/test_workflow_flat/test_workflow.py
+++ b/tests/test_workflow_flat/test_workflow.py
@@ -5,7 +5,7 @@ import pytest
 
 
 @pytest.mark.integration
-def test_hello_world_parent_workflow(workflow_data, workflow_runner):
+def test_workflow(workflow_data, workflow_runner):
     """Test the hello_world parent workflow with fixed inputs and outputs."""
     inputs = {
         "input_files": [

--- a/tests/test_workflow_flat/workflow.wdl
+++ b/tests/test_workflow_flat/workflow.wdl
@@ -6,7 +6,7 @@ workflow hello_world_workflow {
   }
 
   scatter (file in input_files) {
-    call hello_world.hello_world {
+    call hello_world {
       input:
         input_file=file,
         output_filename=basename(file) + ".renamed"

--- a/tests/test_workflow_flat/workflow.wdl
+++ b/tests/test_workflow_flat/workflow.wdl
@@ -1,0 +1,49 @@
+version 1.0
+
+workflow hello_world_workflow {
+  input {
+    Array[File] input_files
+  }
+
+  scatter (file in input_files) {
+    call hello_world.hello_world {
+      input:
+        input_file=file,
+        output_filename=basename(file) + ".renamed"
+    }
+  }
+
+  output {
+    Array[File] renamed_files = hello_world.output_file
+    File single_file = renamed_files[0]
+  }
+}
+
+task hello_world {
+  input {
+    File input_file
+    String output_filename
+  }
+
+  parameter_meta {
+    input_file: {description: "Provide a small input file."}
+    output_filename: {description: "Specify the output filename."}
+  }
+
+  command <<<
+  set -exo pipefail
+
+  >&2 echo "Renaming this input file ~{input_file} to ~{output_filename}"
+
+  mv ~{input_file} ~{output_filename}
+  >>>
+
+  runtime {
+    docker: "debian:stretch-slim"
+  }
+
+  output {
+    File output_file = "${output_filename}"
+  }
+}
+


### PR DESCRIPTION
When finding test_data.json, look first in the current directory before searching for the tests directory.

Also reverts an earlier change that disabled testing of other executors in tests/test_executors.py::test_execution_failure()