### PR TITLE
Doc/manual improvement 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is a plugin for the [pytest](https://docs.pytest.org/en/latest/) un
 
 ## Dependencies
 
-* Python 3.6 or 3.7 (3.8 is not yet fully supported)
+* Python 3.6+
 * At least one of the supported workflow engines:
     * [Cromwell](https://github.com/broadinstitute/cromwell/releases/tag/38) JAR file
     * [dxWDL](https://github.com/dnanexus/dxWDL) JAR file
@@ -42,21 +42,18 @@ $ pip install git+https://github.com/elilillyco/pytest-wdl.git
 
 ### Install optional dependencies
 
-Some optional features of pytest-wdl have additional dependencies that are loaded on-demand. For example, to enable comparison of expected and actual BAM file outputs of a workflow, the [pysam](https://pysam.readthedocs.io/) library is required.
+Some optional features of pytest-wdl have additional dependencies that are loaded on-demand.
 
-The following plugins require an "extras" installation:
+The plugins that have extra dependencies are:
 
-- Data types
-    - bam
-- URL schemes
-    - dx (DNAnexus)
-- Other
-    - progress (show progress bars when downloading files)
+* dx: Support for DNAnexus file storage, and for the dxWDL executor.
+* bam: More intelligent comparison of expected and actual BAM file outputs of a workflow than just comparing MD5 checksums.
+* progress: Show progress bars when downloading remote files.
 
-To install the dependencies for a data type that has extra dependencies:
+To install a plugin's dependencies:
 
 ```
-$ pip install pytest-wdl[<data_type>]
+$ pip install pytest-wdl[<plugin>]
 ```
 
 To do this locally, you can clone the repo and run:
@@ -70,6 +67,15 @@ To install pytest-wdl and **all** extras dependencies:
 ```
 $ pip install pytest-wdl[all]
 ```
+
+## Configuration
+
+Some minimal configuration is required to get started with pytest-wdl. Configuration can be provided via environment variables and/or a config file. To get started, copy one of the following example config files to `$HOME/.pytest_wdl_config.json` and modify as necessary:
+ 
+* [simple](examples/simple.pytest_wdl_config.json): Uses only the miniwdl executor
+* [more complex](examples/complex.pytest_wdl_config.json): Uses both miniwdl and Cromwell; shows how to configure proxies and headers for accessing remote data files in a private repository
+
+See the [manual](https://pytest-wdl.readthedocs.io/en/stable/manual.html#configuration) for more details on configuring pytest-wdl.
 
 ## Usage
 
@@ -108,11 +114,20 @@ workflow call_variants {
     File bai
     Index index
   }
-  ...
+  
+  call variant_caller {
+    input:
+      bam=bam,
+      bai=bai,
+      index=index
+  }
+
   output {
     File vcf = variant_caller.vcf
   }
 }
+
+task variant_caller { ... }
 ```
 
 Input and output data are defined in a `test_data.json` file in the same directory as your test script:
@@ -140,11 +155,13 @@ For details, [read the docs](https://pytest-wdl.readthedocs.io).
 
 ## Contributing
 
-To develop pytest-wdl, clone the repository and install all the dependencies:
+If you would like to contribute code to pytest-wdl, please fork the repository and submit your changes via pull request.
+
+To get started developing pytest-wdl, first install all the development requirements:
 
 ```commandline
 $ git clone https://github.com/EliLillyCo/pytest-wdl.git
-$ pip install -r requirements.txt
+$ make install_development_requirements
 ```
 
 To run the full build and unit tests, run:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ pip install pytest-wdl[all]
 
 ## Configuration
 
-Some minimal configuration is required to get started with pytest-wdl. Configuration can be provided via environment variables and/or a config file. To get started, copy one of the following example config files to `$HOME/.pytest_wdl_config.json` and modify as necessary:
+Some minimal configuration is required to get started with pytest-wdl. Configuration can be provided via environment variables, fixture functions, and/or a config file. To get started, copy one of the following example config files to `$HOME/.pytest_wdl_config.json` and modify as necessary:
  
 * [simple](examples/simple.pytest_wdl_config.json): Uses only the miniwdl executor
 * [more complex](examples/complex.pytest_wdl_config.json): Uses both miniwdl and Cromwell; shows how to configure proxies and headers for accessing remote data files in a private repository
@@ -103,6 +103,8 @@ This test will execute a workflow (such as the following one) with the specified
 # variant_caller.wdl
 version 1.0
 
+import "variant_caller.wdl"
+
 struct Index {
   File fasta
   String organism
@@ -115,7 +117,7 @@ workflow call_variants {
     Index index
   }
   
-  call variant_caller {
+  call variant_caller.variant_caller {
     input:
       bam=bam,
       bai=bai,
@@ -126,8 +128,6 @@ workflow call_variants {
     File vcf = variant_caller.vcf
   }
 }
-
-task variant_caller { ... }
 ```
 
 Input and output data are defined in a `test_data.json` file in the same directory as your test script:

--- a/examples/complex.pytest_wdl_config.json
+++ b/examples/complex.pytest_wdl_config.json
@@ -17,6 +17,7 @@
       "env": "TOKEN"
     }
   ],
+  "default_executors": ["miniwdl", "cromwell"],
   "executors": {
     "cromwell": {
       "java_bin": "/usr/local/bin/java",

--- a/examples/simple.pytest_wdl_config.json
+++ b/examples/simple.pytest_wdl_config.json
@@ -1,0 +1,4 @@
+{
+  "cache_dir": "/tmp/wdl_cache",
+  "default_executors": ["miniwdl"]
+}

--- a/pytest_wdl/core.py
+++ b/pytest_wdl/core.py
@@ -22,8 +22,9 @@ from pytest_wdl.executors import Executor
 from pytest_wdl.localizers import (
     LinkLocalizer, StringLocalizer, JsonLocalizer, UrlLocalizer
 )
+from pytest_wdl.plugins import plugin_factory_map
 from pytest_wdl.url_schemes import install_schemes
-from pytest_wdl.utils import ensure_path, plugin_factory_map
+from pytest_wdl.utils import ensure_path
 
 
 DATA_TYPES = plugin_factory_map(DataFile, "pytest_wdl.data_types")

--- a/pytest_wdl/plugins.py
+++ b/pytest_wdl/plugins.py
@@ -1,0 +1,106 @@
+from collections import defaultdict
+import logging
+import os
+from typing import (
+    Dict, Generic, Iterable, Optional, Type, TypeVar, cast
+)
+
+from pkg_resources import EntryPoint, iter_entry_points
+
+
+LOG = logging.getLogger("pytest-wdl")
+LOG.setLevel(os.environ.get("LOGLEVEL", "WARNING").upper())
+
+T = TypeVar("T")
+
+
+class PluginError(Exception):
+    pass
+
+
+class PluginFactory(Generic[T]):
+    """
+    Lazily loads a plugin class associated with a data type.
+    """
+    def __init__(self, entry_point: EntryPoint, return_type: Type[T]):
+        self.entry_point = entry_point
+        self.return_type = return_type
+        self.factory = None
+
+    def __call__(self, *args, **kwargs) -> T:
+        if self.factory is None:
+            try:
+                self.factory = self.entry_point.resolve()
+            except ImportError as err:
+                raise PluginError(
+                    f"Could not load plugin {self.entry_point.name}"
+                ) from err
+
+        plugin = self.factory(*args, **kwargs)
+
+        if not isinstance(plugin, self.return_type):  # TODO: test this
+            raise RuntimeError(
+                f"Expected plugin {plugin} to be an instance of {self.return_type}"
+            )
+
+        return cast(self.return_type, plugin)
+
+
+def plugin_factory_map(
+    return_type: Type[T],
+    group: Optional[str] = None,
+    entry_points: Optional[Iterable[EntryPoint]] = None
+) -> Dict[str, PluginFactory[T]]:
+    """
+    Creates a mapping of entry point name to `PluginFactory` for all discovered
+    entry points in the specified group.
+
+    Args:
+        group: Entry point group name
+        return_type: Expected return type
+        entry_points:
+
+    Returns:
+        Dict mapping entry point name to `PluginFactory` instances
+    """
+    if entry_points is None:
+        entry_points = iter_entry_points(group=group)
+
+    entry_point_map = defaultdict(list)
+
+    for entry_point in entry_points:
+        entry_point_map[entry_point.name].append(entry_point)
+
+    factory_map = {}
+
+    for name, points in entry_point_map.items():
+        if len(points) > 1:
+            # Filter out built-ins
+            points = list(filter(
+                lambda point: not point.module_name.startswith("pytest_wdl"), points
+            ))
+            if len(points) > 1:
+                raise RuntimeError(
+                    f"Multiple third-party plugins found in group {group} with the "
+                    f"same name: {name}"
+                )
+
+        ep = points[0]
+
+        try:
+            ep.require()
+        except ResourceWarning as rerr:
+            LOG.warning(
+                "Plugin %s is not available because it is missing an extra "
+                "dependency: %s", name, str(rerr)
+            )
+            continue
+        except PluginError as perr:
+            LOG.warning(
+                "Error while loading plugin %s: %s", name, str(perr)
+            )
+            continue
+
+        factory_map[name] = PluginFactory(ep, return_type)
+
+    return factory_map

--- a/pytest_wdl/providers/dx.py
+++ b/pytest_wdl/providers/dx.py
@@ -83,7 +83,11 @@ def login(logout: bool = False, interactive: bool = True):
     if dxpy.SECURITY_CONTEXT:
         yield
     else:
-        conf = config.get_instance().get_provider_defaults("dxwdl")
+        if config.get_instance():
+            conf = config.get_instance().get_provider_defaults("dxwdl")
+        else:
+            conf = {}
+
         username = conf.get("username")
         token = conf.get("token")
 

--- a/pytest_wdl/providers/dx.py
+++ b/pytest_wdl/providers/dx.py
@@ -30,19 +30,17 @@ from pytest_wdl.executors import (
     parse_wdl,
 )
 from pytest_wdl.localizers import UrlLocalizer
+from pytest_wdl.plugins import PluginError
 from pytest_wdl.url_schemes import Method, Request, Response, UrlHandler
-from pytest_wdl.utils import LOG, PluginError, ensure_path, verify_digests
+from pytest_wdl.utils import LOG, ensure_path, verify_digests
 
 try:
     # test whether dxpy is installed and the user is logged in
     import dxpy
-    assert dxpy.SECURITY_CONTEXT
-    assert dxpy.whoami()
-except Exception as err:
+except ImportError as err:
     raise PluginError(
-        "DNAnexus (dx) extensions require that a) you install 'dxpy' "
-        "(try 'pip install dxpy') and b) you log into your DNAnexus account via the "
-        "command line (try 'dx login')."
+        "DNAnexus (dx) extensions require that you install 'dxpy' "
+        "(try 'pip install dxpy')."
     ) from err
 
 from dxpy.scripts import dx
@@ -63,7 +61,19 @@ STDERR_LOG = "STDERR"
 
 
 @contextlib.contextmanager
-def login(logout: bool = False):
+def login(logout: bool = False, interactive: bool = True):
+    """
+    Checks that the user is logged into DNAnexus, otherwise log them in.
+
+    Args:
+        logout: Whether to log out before exiting the context. Ignored if the user is
+            already logged in.
+        interactive: Whether to allow interactive login.
+
+    Raises:
+        PluginError: if `interactive` is `False` and the user cannot be logged in
+            non-interactively
+    """
     if dxpy.SECURITY_CONTEXT:
         try:
             dxpy.whoami()
@@ -94,13 +104,24 @@ def login(logout: bool = False):
 
         try:
             if not token and "password" in conf:
+                # Use configured credentials to log user in automatically
                 with patch("builtins.input", return_value=username), \
                         patch("getpass.getpass", return_value=conf["password"]):
                     dx.login(args)
+            elif not (token or interactive):
+                raise ValueError(
+                    "User is not logged in, credentials were not provided, and "
+                    "interactive login is not allowed"
+                )
             else:
                 # If token is not specified, this will require interactive login
                 dx.login(args)
+
             yield
+        except Exception as lerr:
+            raise PluginError(
+                "DNAnexus (dx) extensions require you to be logged into your account"
+            ) from lerr
         finally:
             if logout:
                 dx.logout(args)

--- a/pytest_wdl/url_schemes.py
+++ b/pytest_wdl/url_schemes.py
@@ -21,7 +21,8 @@ from urllib.request import BaseHandler, Request, build_opener, install_opener
 
 from pkg_resources import iter_entry_points
 
-from pytest_wdl.utils import LOG, PluginError, PluginFactory, verify_digests
+from pytest_wdl.plugins import PluginError, PluginFactory
+from pytest_wdl.utils import LOG, verify_digests
 
 try:
     from tqdm import tqdm as progress

--- a/pytest_wdl/utils.py
+++ b/pytest_wdl/utils.py
@@ -15,7 +15,6 @@
 #    limitations under the License.
 #
 # TODO: some of the code here can be replaced by functions in xphyle.{paths,utils}
-from collections import defaultdict
 import contextlib
 import fnmatch
 import hashlib
@@ -26,11 +25,8 @@ import re
 import shutil
 import stat
 import tempfile
-from typing import (
-    Dict, Generic, Iterable, Optional, Sequence, Type, TypeVar, Union, cast
-)
+from typing import Optional, Sequence, Union, cast
 
-from pkg_resources import EntryPoint, iter_entry_points
 from py._path.local import LocalPath
 
 
@@ -42,100 +38,6 @@ ENV_CLASSPATH = "CLASSPATH"
 DEFAULT_CLASSPATH = "."
 
 UNSAFE_RE = re.compile(r"[^\w.-]")
-
-T = TypeVar("T")
-
-
-class PluginError(Exception):
-    pass
-
-
-class PluginFactory(Generic[T]):
-    """
-    Lazily loads a plugin class associated with a data type.
-    """
-    def __init__(self, entry_point: EntryPoint, return_type: Type[T]):
-        self.entry_point = entry_point
-        self.return_type = return_type
-        self.factory = None
-
-    def __call__(self, *args, **kwargs) -> T:
-        if self.factory is None:
-            try:
-                self.factory = self.entry_point.resolve()
-            except ImportError as err:
-                raise PluginError(
-                    f"Could not load plugin {self.entry_point.name}"
-                ) from err
-
-        plugin = self.factory(*args, **kwargs)
-
-        if not isinstance(plugin, self.return_type):  # TODO: test this
-            raise RuntimeError(
-                f"Expected plugin {plugin} to be an instance of {self.return_type}"
-            )
-
-        return cast(self.return_type, plugin)
-
-
-def plugin_factory_map(
-    return_type: Type[T],
-    group: Optional[str] = None,
-    entry_points: Optional[Iterable[EntryPoint]] = None
-) -> Dict[str, PluginFactory[T]]:
-    """
-    Creates a mapping of entry point name to `PluginFactory` for all discovered
-    entry points in the specified group.
-
-    Args:
-        group: Entry point group name
-        return_type: Expected return type
-        entry_points:
-
-    Returns:
-        Dict mapping entry point name to `PluginFactory` instances
-    """
-    if entry_points is None:
-        entry_points = iter_entry_points(group=group)
-
-    entry_point_map = defaultdict(list)
-
-    for entry_point in entry_points:
-        entry_point_map[entry_point.name].append(entry_point)
-
-    factory_map = {}
-
-    for name, points in entry_point_map.items():
-        if len(points) > 1:
-            # Filter out built-ins
-            points = list(filter(
-                lambda point: not point.module_name.startswith("pytest_wdl"), points
-            ))
-            if len(points) > 1:
-                raise RuntimeError(
-                    f"Multiple third-party plugins found in group {group} with the "
-                    f"same name: {name}"
-                )
-
-        ep = points[0]
-
-        try:
-            ep.require()
-        except ResourceWarning as rerr:
-            LOG.warning(
-                "Plugin %s is not available because it is missing an extra "
-                "dependency: %s", name, str(rerr)
-            )
-            continue
-        except PluginError as perr:
-            LOG.warning(
-                "Error while loading plugin %s: %s", name, str(perr)
-            )
-            continue
-
-        factory_map[name] = PluginFactory(ep, return_type)
-
-    return factory_map
 
 
 def safe_string(s: str, replacement: str = "_") -> str:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ extras_require = {
     "bam": ["pysam>=0.15.4"],
     "dx": ["dxpy"],
     "progress": ["tqdm"],
-    "miniwdl": ["docker>=3.4.0"],
 }
 extras_require["all"] = list(set(
     lib

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         ],
         "pytest_wdl.executors": [
             "cromwell = pytest_wdl.executors.cromwell:CromwellExecutor",
-            "miniwdl = pytest_wdl.executors.miniwdl:MiniwdlExecutor[miniwdl]",
+            "miniwdl = pytest_wdl.executors.miniwdl:MiniwdlExecutor",
             "dxwdl = pytest_wdl.providers.dx:DxWdlExecutor[dx]",
         ],
         "pytest_wdl.url_schemes": [

--- a/test_plugins.py
+++ b/test_plugins.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock
+
+import pytest
+
+from pytest_wdl.plugins import plugin_factory_map
+
+
+def test_plugin_factory_map():
+    ep1 = Mock()
+    ep1.name = "foo"
+    ep1.module_name = "pytest_wdl.foo"
+    ep2 = Mock()
+    ep2.name = "foo"
+    ep2.module_name = "bar.baz"
+    entry_points = [ep1, ep2]
+    pfmap = plugin_factory_map(None, entry_points=entry_points)
+    assert len(pfmap) == 1
+    assert "foo" in pfmap
+    assert pfmap["foo"].entry_point == ep2
+
+    ep3 = Mock()
+    ep3.name = "foo"
+    ep3.module_name = "blorf.bleep"
+    entry_points.append(ep3)
+    with pytest.raises(RuntimeError):
+        plugin_factory_map(None, entry_points=entry_points)

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -9,8 +9,9 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 
 from pytest_wdl.executors import parse_wdl
+from pytest_wdl.plugins import PluginError
 from pytest_wdl.url_schemes import Response
-from pytest_wdl.utils import PluginError, tempdir
+from pytest_wdl.utils import tempdir
 
 SKIP_REASON = "dxpy is not installed; DNAnexus URL handler and dxWDL executor will " \
               "not be tested"

--- a/tests/test_dx.py
+++ b/tests/test_dx.py
@@ -12,12 +12,15 @@ from pytest_wdl.executors import parse_wdl
 from pytest_wdl.url_schemes import Response
 from pytest_wdl.utils import PluginError, tempdir
 
-SKIP_REASON = "dxpy is not installed or user is not logged into a DNAnexus account; " \
-              "DNAnexus URL handler and dxWDL executor will not be tested"
+SKIP_REASON = "dxpy is not installed; DNAnexus URL handler and dxWDL executor will " \
+              "not be tested"
 
 try:
     dx = pytest.importorskip("pytest_wdl.providers.dx", reason=SKIP_REASON)
     dxpy = dx.dxpy
+    # Force non-interactive login since we may be running in a CI/CD environment
+    with dx.login(interactive=False):
+        assert dxpy.whoami()
 except PluginError as err:
     dxpy = None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,6 @@
 import os
 import stat
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 
@@ -28,7 +27,6 @@ from pytest_wdl.utils import (
     find_executable_path,
     find_project_path,
     env_map,
-    plugin_factory_map,
     safe_string,
 )
 from . import setenv, make_executable
@@ -187,27 +185,6 @@ def test_env_map():
         assert env_map({"http": "FOOVAR1", "https": "FOOVAR2"}) == {
             "http": "http://foo.com"
         }
-
-
-def test_plugin_factory_map():
-    ep1 = Mock()
-    ep1.name = "foo"
-    ep1.module_name = "pytest_wdl.foo"
-    ep2 = Mock()
-    ep2.name = "foo"
-    ep2.module_name = "bar.baz"
-    entry_points = [ep1, ep2]
-    pfmap = plugin_factory_map(None, entry_points=entry_points)
-    assert len(pfmap) == 1
-    assert "foo" in pfmap
-    assert pfmap["foo"].entry_point == ep2
-
-    ep3 = Mock()
-    ep3.name = "foo"
-    ep3.module_name = "blorf.bleep"
-    entry_points.append(ep3)
-    with pytest.raises(RuntimeError):
-        plugin_factory_map(None, entry_points=entry_points)
 
 
 def test_safe_string():


### PR DESCRIPTION
* I made some improvements to the README and manual based on suggestions from Mike Lin, including an additional example configuration file.
* I also factored out the plugin-related code to it's own module.
* I relaxed the restrictions on the dx plugin to not require the user to be logged in - instead, the user is logged in when necessary using either configured credentials or token, or interactively. I made the tests force a non-interactive login since they might be run in a CI/CD environment.