### PR TITLE
Add 'callback' keyword to workflow_runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ tests = tests
 # Use this option to show full stack trace for errors
 #pytestopts = --full-trace
 #pytestopts = -ra --tb=short
-pytestopts =  -s -vv --show-capture=all -m "not remote"
-#pytestopts = -s -vv --show-capture=all -m "not integration"
+pytestopts =  -vv  -m "not remote"
+#pytestopts = -vv --show-capture=all -m "not integration"
 
 all: clean install install_extras install_development_requirements test test_release_setup
 

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -365,6 +365,15 @@ The remaining arguments to `workflow_runner` are optional:
 * `workflow_name`: The name of the workflow to execute in the WDL script. If not specified, the name of the workflow is extracted from the WDL file.
 * `inputs_file`: Specify the inputs.json file to use, or the path to the inputs.json file to write, instead of a temp file.
 * `imports_file`: Specify the imports file to use. By default, all WDL files under the test context directory are imported if an `import_paths.txt` file is not provided.
+* `executors`: Optional list of executors to use to run the workflow. Each executor will be run in a [subtest](https://github.com/pytest-dev/pytest-subtests). If not specified the [default_executors](#configuration) are used.
+* `callback`: An optional function that is called after each successful workflow execution. Take three arguments:
+
+    ```python
+    from pathlib import Path
+    
+    def callback(executor_name: str, execution_dir: Path, outputs: dict):
+      ...
+    ```
 
 You can also pass executor-specific keyword arguments. 
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 import json
+from pathlib import Path
 from typing import cast
 
 import pytest
@@ -34,14 +35,14 @@ def test_executors(workflow_data, workflow_runner, executor):
         "in_txt": workflow_data["in_txt"],
         "in_int": 1
     }
-    outputs = {
+    expected = {
         "out_txt": workflow_data["out_txt"],
         "out_int": 1
     }
     workflow_runner(
         "test.wdl",
         inputs,
-        outputs,
+        expected,
         executors=[executor]
     )
     # Test with the old workflow_runner signature
@@ -49,7 +50,7 @@ def test_executors(workflow_data, workflow_runner, executor):
         "test.wdl",
         "cat_file",
         inputs,
-        outputs,
+        expected,
         executors=[executor]
     )
 
@@ -60,15 +61,23 @@ def test_multiple_executors(workflow_data, workflow_runner):
         "in_txt": workflow_data["in_txt"],
         "in_int": 1
     }
-    outputs = {
+    expected = {
         "out_txt": workflow_data["out_txt"],
         "out_int": 1
     }
+
+    def callback(executor: str, execution_dir: Path, outputs: dict):
+        assert executor in WORKFLOW_EXECUTORS
+        assert execution_dir.exists()
+        for param in ("cat_file.out_txt", "cat_file.out_int"):
+            assert param in outputs
+
     workflow_runner(
         "test.wdl",
         inputs,
-        outputs,
-        executors=WORKFLOW_EXECUTORS
+        expected,
+        executors=WORKFLOW_EXECUTORS,
+        callback=callback
     )
 
 


### PR DESCRIPTION
I refactored the code in the workflow_runner fixture into a separate class. I added support for a `callback` keyword for a function to be called after each successful workflow execution.