### PR TITLE
Upgrade miniwdl dependency to 0.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ tests = tests
 # Use this option to show full stack trace for errors
 #pytestopts = --full-trace
 #pytestopts = -ra --tb=short
-pytestopts =  -vv  -m "not remote"
+pytestopts =  -vv --show-capture=all -m "not remote"
 #pytestopts = -vv --show-capture=all -m "not integration"
 
 all: clean install install_extras install_development_requirements test test_release_setup

--- a/pytest_wdl/fixtures.py
+++ b/pytest_wdl/fixtures.py
@@ -305,13 +305,23 @@ class WorkflowRunner:
         executors, call_args = self._args(*args, **kwargs)
 
         outputs = {}
+        failed = []
 
         if len(executors) == 1:
             outputs[executors[0]] = self._run_test(executors[0], **call_args)
         else:
             for executor_name in executors:
                 with self._subtests.test(executor_name=executor_name):
-                    outputs[executor_name] = self._run_test(executor_name, **call_args)
+                    try:
+                        outputs[executor_name] = self._run_test(
+                            executor_name, **call_args
+                        )
+                    except:
+                        failed.append(executor_name)
+                        raise
+
+        if failed:
+            raise AssertionError(f"One or more sub-tests failed: {failed}")
 
         return outputs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ dxpy==0.290.1
 humanfriendly==6.0
 idna==2.8
 importlib-metadata==1.5.0
-lark-parser==0.7.8
-miniwdl==0.6.4
+lark-parser==0.8.1
+miniwdl==0.7.0
 more-itertools==8.2.0
 packaging==20.1
 pluggy==0.13.1

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         "pytest>=5.1",
         "subby>=0.1.6",
-        "miniwdl==0.6.4",
+        "miniwdl==0.7.0",
         "pytest-subtests",
         "xphyle>=4.1.3",
     ],


### PR DESCRIPTION
Note: this version introduces the `error_json` option to CLI.runner(). This should enable us to recover the failure error after catching SystemExit, so we can finally tackle #103. I'll do that in a separate PR.