### PR TITLE
Bump Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
 - make install_development_requirements
 - make install
 before_script:
-- wget https://github.com/broadinstitute/cromwell/releases/download/48/cromwell-48.jar -O /tmp/cromwell-48.jar
-- export CROMWELL_JAR=/tmp/cromwell-48.jar
+- wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar -O /tmp/cromwell-53.1.jar
+- export CROMWELL_JAR=/tmp/cromwell-53.1.jar
 script:
 - make test
 - make test_release_setup

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package is a plugin for the [pytest](https://docs.pytest.org/en/latest/) un
 * Python 3.6+
 * At least one of the supported workflow engines:
     * [Miniwdl](https://github.com/chanzuckerberg/miniwdl) - automatically installed as a dependency of pytest-wdl
-    * [Cromwell](https://github.com/broadinstitute/cromwell/releases/tag/48) JAR file
+    * [Cromwell](https://github.com/broadinstitute/cromwell/releases/tag/53.1) JAR file
         * **Cromwell Server**: Any Cromwell instance remotely running in Server mode
     * [dxWDL](https://github.com/dnanexus/dxWDL) JAR file
 * Java-based workflow engines (e.g. Cromwell and dxWDL) require a Java runtime (typically 1.8+)

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -7,7 +7,7 @@ pytest-wdl is a plugin for the [pytest](https://docs.pytest.org/en/latest/) unit
 * Python 3.6+
 * At least one of the supported workflow engines (see [Limitations](#known-limitations) for known limitations of these workflow engines):
     * [Miniwdl](https://github.com/chanzuckerberg/miniwdl) (v0.6.4 is automatically installed as a dependency of pytest-wdl)
-    * [Cromwell](https://github.com/broadinstitute/cromwell/releases/) JAR file (pytest-wdl is currently tested with Cromwell v48)
+    * [Cromwell](https://github.com/broadinstitute/cromwell/releases/) JAR file (pytest-wdl is currently tested with Cromwell v53.1)
     * [dxWDL](https://github.com/dnanexus/dxWDL) JAR file (pytest-wdl is currently tested with dxWDL v1.42)
 * Java-based workflow engines (e.g. Cromwell and dxWDL) require a Java runtime (typically 1.8+)
 * If your WDL tasks depend on Docker images, make sure to have the [Docker](https://www.docker.com/get-started) daemon running

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-bleach==3.1.1
+bleach==3.1.5
 coverage==5.0.3
 docutils==0.16
 keyring==21.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 coloredlogs==10.0
-cryptography==2.2.2
+cryptography==2.3
 docker==4.2.0
 dxpy==0.290.1
 humanfriendly==6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ chardet==3.0.4
 coloredlogs==10.0
 cryptography==2.3
 docker==4.2.0
-dxpy==0.290.1
+dxpy==0.297.1
 humanfriendly==6.0
 idna==2.8
 importlib-metadata==1.5.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     py_modules=["pytest_wdl"],
     packages=find_packages(),
     install_requires=[
-        "pytest==5.3.5",
+        "pytest<=5.3.5",
         "subby>=0.1.6",
         "miniwdl==0.7.0",
         "pytest-subtests",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 extras_require = {
     "bam": ["pysam>=0.15.4"],
-    "dx": ["dxpy"],
+    "dx": ["dxpy>=0.297.1"],
     "http": ["requests"],
     "progress": ["tqdm"],
     "yaml": ["pyyaml"],


### PR DESCRIPTION
- closes #106: requires `dxpy>=0.297.1` to make sure `cryptography` 2.3+ is used.
- closes #138: bumps `bleach` to 3.1.5
- workaround #139: allow `pytest<=5.3.5` 
  - current `develop` has a workaround in place that locks `pytest==5.3.5`, but prior versions work as well (no testing to know which do though). Relaxes the workaround some but still has the issue in place of not being compatible with more recent versions of `pytest`.
- updates test setup and documentation to latest `Cromwell` version `53.1`