### PR TITLE
Add unredirected HTTP headers

### DIFF
--- a/pytest_wdl/localizers.py
+++ b/pytest_wdl/localizers.py
@@ -175,7 +175,7 @@ def download_file(
     req = request.Request(url)
     if http_headers:
         for name, value in http_headers.items():
-            req.add_header(name, value)
+            req.add_unredirected_header(name, value)
     if proxies:
         # TODO: Should we only set the proxy associated with the URL scheme?
         #  Should we raise an exception if there is not a proxy defined for


### PR DESCRIPTION
replaces `request.Request().add_header()` usage with `request.Request().add_unredirected_header()` so that headers do not persist through redirects. There are cases where persisting these headers following redirects will result in a 400 bad request.