### PR TITLE
Release 1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
 - make install_development_requirements
 - make install
 before_script:
-- wget https://github.com/broadinstitute/cromwell/releases/download/48/cromwell-48.jar -O /tmp/cromwell-48.jar
-- export CROMWELL_JAR=/tmp/cromwell-48.jar
+- wget https://github.com/broadinstitute/cromwell/releases/download/53.1/cromwell-53.1.jar -O /tmp/cromwell-53.1.jar
+- export CROMWELL_JAR=/tmp/cromwell-53.1.jar
 script:
 - make test
 - make test_release_setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ deploy:
   skip_existing: true
   on:
     tags: true
-    branch: master
+    branch: main

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 ## Development
 
 
+## v1.4.1 (2020.11.17)
+* Replaces remote file localization method for adding HTTP headers to only add headers on initial request and not redirects.
+* Updated `dxpy` minimum to `0.297.1` to be able to use `cryptography` version `2.3` ([#106](https://github.com/EliLillyCo/pytest-wdl/pull/106))
+* Upgraded `bleach` to `3.1.5` ([#138](https://github.com/EliLillyCo/pytest-wdl/pull/138))
+* Constrains `pytest` version `<=5.3.5` to avoid breaking changes in `pytest` ([#139](https://github.com/EliLillyCo/pytest-wdl/pull/139))
+* Upgrades `Cromwell` to version `53.1` in test setup and documentation.
 
 ## v1.4.0 (2020.02.26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,14 @@
 # Changes
 
+## Development
+
+
+
 ## v1.4.0 (2020.02.26)
 
 * Added support for YAML data and configuration files (#116)
 * Added a Cromwell Server executor (thanks @pamagee!)
-* Added ability to specify tests in JSON/WDL (#117)
+* Added ability to specify tests in JSON/YAML (#117)
 * Updated docs and testing to latest version of Cromwell (v48)
 * Added an optional `callback` parameter to `workflow_runner`
 * Fix miniwdl executor when there are no inputs (thanks @mlin!)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ tests = tests
 # Use this option to show full stack trace for errors
 #pytestopts = --full-trace
 #pytestopts = -ra --tb=short
-pytestopts =  -vv  -m "not remote"
+pytestopts =  -vv --show-capture=all -m "not remote"
 #pytestopts = -vv --show-capture=all -m "not integration"
 
 all: clean install install_extras install_development_requirements test test_release_setup

--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,4 @@ release: clean tag
 		-H "Content-Type:application/json" \
 		-H "Authorization: token $(token)" \
 		https://api.github.com/repos/$(repo)/releases \
-		-d '{"tag_name":"$(version)","target_commitish": "master","name": "$(version)","body": "$(desc)","draft": false,"prerelease": false}'
+		-d '{"tag_name":"$(version)","target_commitish": "main","name": "$(version)","body": "$(desc)","draft": false,"prerelease": false}'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package is a plugin for the [pytest](https://docs.pytest.org/en/latest/) un
 * Python 3.6+
 * At least one of the supported workflow engines:
     * [Miniwdl](https://github.com/chanzuckerberg/miniwdl) - automatically installed as a dependency of pytest-wdl
-    * [Cromwell](https://github.com/broadinstitute/cromwell/releases/tag/48) JAR file
+    * [Cromwell](https://github.com/broadinstitute/cromwell/releases/tag/53.1) JAR file
         * **Cromwell Server**: Any Cromwell instance remotely running in Server mode
     * [dxWDL](https://github.com/dnanexus/dxWDL) JAR file
 * Java-based workflow engines (e.g. Cromwell and dxWDL) require a Java runtime (typically 1.8+)

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For details, [read the docs](https://pytest-wdl.readthedocs.io).
 You can get started with pytest-wdl with no configuration required. However, some advanced features can be configured via environment variables, fixture functions, and/or a config file. To get started, copy one of the following example config files to `$HOME/.pytest_wdl_config.json` and modify as necessary:
  
 * [simple](examples/config/simple.pytest_wdl_config.json): Uses only the miniwdl executor
-* [more complex](examples/complex.pytest_wdl_config.json): Uses both miniwdl and Cromwell; shows how to configure proxies and headers for accessing remote data files in a private repository
+* [more complex](examples/config/complex.pytest_wdl_config.json): Uses both miniwdl and Cromwell; shows how to configure proxies and headers for accessing remote data files in a private repository
 
 See the [manual](https://pytest-wdl.readthedocs.io/en/stable/manual.html#configuration) for more details on configuring pytest-wdl.
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ For details, [read the docs](https://pytest-wdl.readthedocs.io).
 
 You can get started with pytest-wdl with no configuration required. However, some advanced features can be configured via environment variables, fixture functions, and/or a config file. To get started, copy one of the following example config files to `$HOME/.pytest_wdl_config.json` and modify as necessary:
  
-* [simple](examples/simple.pytest_wdl_config.json): Uses only the miniwdl executor
+* [simple](examples/config/simple.pytest_wdl_config.json): Uses only the miniwdl executor
 * [more complex](examples/complex.pytest_wdl_config.json): Uses both miniwdl and Cromwell; shows how to configure proxies and headers for accessing remote data files in a private repository
 
 See the [manual](https://pytest-wdl.readthedocs.io/en/stable/manual.html#configuration) for more details on configuring pytest-wdl.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Travis CI](https://travis-ci.com/EliLillyCo/pytest-wdl.svg?branch=master)](https://travis-ci.com/EliLillyCo/pytest-wdl)
-[![Code Coverage](https://codecov.io/gh/elilillyco/pytest-wdl/branch/master/graph/badge.svg)](https://codecov.io/gh/elilillyco/pytest-wdl)
+[![Travis CI](https://travis-ci.com/EliLillyCo/pytest-wdl.svg?branch=main)](https://travis-ci.com/EliLillyCo/pytest-wdl)
+[![Code Coverage](https://codecov.io/gh/elilillyco/pytest-wdl/branch/main/graph/badge.svg)](https://codecov.io/gh/elilillyco/pytest-wdl)
 [![Documentation Status](https://readthedocs.org/projects/pytest-wdl/badge/?version=latest)](https://pytest-wdl.readthedocs.io/en/latest/?badge=latest)
 
 <img width="200" alt="logo" src="docs/source/logo.png"/>

--- a/README.md
+++ b/README.md
@@ -71,15 +71,6 @@ To install pytest-wdl and **all** extras dependencies:
 $ pip install pytest-wdl[all]
 ```
 
-## Configuration
-
-Some minimal configuration is required to get started with pytest-wdl. Configuration can be provided via environment variables, fixture functions, and/or a config file. To get started, copy one of the following example config files to `$HOME/.pytest_wdl_config.json` and modify as necessary:
- 
-* [simple](examples/simple.pytest_wdl_config.json): Uses only the miniwdl executor
-* [more complex](examples/complex.pytest_wdl_config.json): Uses both miniwdl and Cromwell; shows how to configure proxies and headers for accessing remote data files in a private repository
-
-See the [manual](https://pytest-wdl.readthedocs.io/en/stable/manual.html#configuration) for more details on configuring pytest-wdl.
-
 ## Usage
 
 The pytest-wdl plugin provides a set of fixtures for use with pytest. Here is a quick example that tests the following workflow.
@@ -178,6 +169,15 @@ def test_variant_caller(workflow_data, workflow_runner):
 ```
 
 For details, [read the docs](https://pytest-wdl.readthedocs.io).
+
+## Configuration
+
+You can get started with pytest-wdl with no configuration required. However, some advanced features can be configured via environment variables, fixture functions, and/or a config file. To get started, copy one of the following example config files to `$HOME/.pytest_wdl_config.json` and modify as necessary:
+ 
+* [simple](examples/simple.pytest_wdl_config.json): Uses only the miniwdl executor
+* [more complex](examples/complex.pytest_wdl_config.json): Uses both miniwdl and Cromwell; shows how to configure proxies and headers for accessing remote data files in a private repository
+
+See the [manual](https://pytest-wdl.readthedocs.io/en/stable/manual.html#configuration) for more details on configuring pytest-wdl.
 
 ## Contributing
 

--- a/docs/source/manual.md
+++ b/docs/source/manual.md
@@ -7,7 +7,7 @@ pytest-wdl is a plugin for the [pytest](https://docs.pytest.org/en/latest/) unit
 * Python 3.6+
 * At least one of the supported workflow engines (see [Limitations](#known-limitations) for known limitations of these workflow engines):
     * [Miniwdl](https://github.com/chanzuckerberg/miniwdl) (v0.6.4 is automatically installed as a dependency of pytest-wdl)
-    * [Cromwell](https://github.com/broadinstitute/cromwell/releases/) JAR file (pytest-wdl is currently tested with Cromwell v48)
+    * [Cromwell](https://github.com/broadinstitute/cromwell/releases/) JAR file (pytest-wdl is currently tested with Cromwell v53.1)
     * [dxWDL](https://github.com/dnanexus/dxWDL) JAR file (pytest-wdl is currently tested with dxWDL v1.42)
 * Java-based workflow engines (e.g. Cromwell and dxWDL) require a Java runtime (typically 1.8+)
 * If your WDL tasks depend on Docker images, make sure to have the [Docker](https://www.docker.com/get-started) daemon running

--- a/pytest_wdl/fixtures.py
+++ b/pytest_wdl/fixtures.py
@@ -305,13 +305,23 @@ class WorkflowRunner:
         executors, call_args = self._args(*args, **kwargs)
 
         outputs = {}
+        failed = []
 
         if len(executors) == 1:
             outputs[executors[0]] = self._run_test(executors[0], **call_args)
         else:
             for executor_name in executors:
                 with self._subtests.test(executor_name=executor_name):
-                    outputs[executor_name] = self._run_test(executor_name, **call_args)
+                    try:
+                        outputs[executor_name] = self._run_test(
+                            executor_name, **call_args
+                        )
+                    except:
+                        failed.append(executor_name)
+                        raise
+
+        if failed:
+            raise AssertionError(f"One or more sub-tests failed: {failed}")
 
         return outputs
 

--- a/pytest_wdl/localizers.py
+++ b/pytest_wdl/localizers.py
@@ -175,7 +175,7 @@ def download_file(
     req = request.Request(url)
     if http_headers:
         for name, value in http_headers.items():
-            req.add_header(name, value)
+            req.add_unredirected_header(name, value)
     if proxies:
         # TODO: Should we only set the proxy associated with the URL scheme?
         #  Should we raise an exception if there is not a proxy defined for

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-bleach==3.1.1
+bleach==3.1.5
 coverage==5.0.3
 docutils==0.16
 keyring==21.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
 coloredlogs==10.0
-cryptography==2.2.2
+cryptography==2.3
 docker==4.2.0
 dxpy==0.290.1
 humanfriendly==6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ dxpy==0.290.1
 humanfriendly==6.0
 idna==2.8
 importlib-metadata==1.5.0
-lark-parser==0.7.8
-miniwdl==0.6.4
+lark-parser==0.8.1
+miniwdl==0.7.0
 more-itertools==8.2.0
 packaging==20.1
 pluggy==0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ chardet==3.0.4
 coloredlogs==10.0
 cryptography==2.3
 docker==4.2.0
-dxpy==0.290.1
+dxpy==0.297.1
 humanfriendly==6.0
 idna==2.8
 importlib-metadata==1.5.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         "pytest>=5.1",
         "subby>=0.1.6",
-        "miniwdl==0.6.4",
+        "miniwdl==0.7.0",
         "pytest-subtests",
         "xphyle>=4.1.3",
     ],

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     py_modules=["pytest_wdl"],
     packages=find_packages(),
     install_requires=[
-        "pytest>=5.3.5",
+        "pytest==5.3.5",
         "subby>=0.1.6",
         "miniwdl==0.6.4",
         "pytest-subtests",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     py_modules=["pytest_wdl"],
     packages=find_packages(),
     install_requires=[
-        "pytest==5.3.5",
+        "pytest<=5.3.5",
         "subby>=0.1.6",
         "miniwdl==0.7.0",
         "pytest-subtests",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 extras_require = {
     "bam": ["pysam>=0.15.4"],
-    "dx": ["dxpy"],
+    "dx": ["dxpy>=0.297.1"],
     "http": ["requests"],
     "progress": ["tqdm"],
     "yaml": ["pyyaml"],

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     py_modules=["pytest_wdl"],
     packages=find_packages(),
     install_requires=[
-        "pytest>=5.1",
+        "pytest>=5.3.5",
         "subby>=0.1.6",
         "miniwdl==0.6.4",
         "pytest-subtests",

--- a/tests/test_workflow/hello_world/tests/test_data.json
+++ b/tests/test_workflow/hello_world/tests/test_data.json
@@ -1,6 +1,6 @@
 {
   "test_file": {
-    "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/master/README.md",
+    "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/main/README.md",
     "path": "pytest_wdl_readme.md"
   }
 }

--- a/tests/test_workflow/tests/test_data.json
+++ b/tests/test_workflow/tests/test_data.json
@@ -1,6 +1,6 @@
 {
   "test_file": {
-    "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/master/README.md",
+    "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/main/README.md",
     "path": "pytest_wdl_readme.md"
   }
 }

--- a/tests/test_workflow_flat/test_data.json
+++ b/tests/test_workflow_flat/test_data.json
@@ -1,6 +1,6 @@
 {
   "test_file": {
-    "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/master/README.md",
+    "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/main/README.md",
     "path": "pytest_wdl_readme.md"
   }
 }

--- a/tests/test_workflow_flat/test_loader.json
+++ b/tests/test_workflow_flat/test_loader.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "test_file": {
-      "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/master/README.md",
+      "url": "https://raw.githubusercontent.com/EliLillyCo/pytest-wdl/main/README.md",
       "path": "pytest_wdl_readme.md"
     }
   },


### PR DESCRIPTION
* Replaces remote file localization method for adding HTTP headers to only add headers on initial request and not redirects.
* Updated `dxpy` minimum to `0.297.1` to be able to use `cryptography` version `2.3` ([#106](https://github.com/EliLillyCo/pytest-wdl/pull/106))
* Upgraded `bleach` to `3.1.5` ([#138](https://github.com/EliLillyCo/pytest-wdl/pull/138))
* Constrains `pytest` version `<=5.3.5` to avoid breaking changes in `pytest` ([#139](https://github.com/EliLillyCo/pytest-wdl/pull/139))
* Upgrades `Cromwell` to version `53.1` in test setup and documentation.

This PR is also against `main`, as this will replace `master` branch which is reflected in other changes here.
