### PR TITLE
freeze docs requirements to fix build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-Sphinx>=2.1.2
-recommonmark>=0.5.0
-sphinx_rtd_theme>=0.4.3
-sphinx-markdown-tables>=0.0.9
-sphinxcontrib-apidoc>=0.3.0
+Sphinx==2.1.2
+recommonmark==0.5.0
+sphinx_rtd_theme==0.4.3
+sphinx-markdown-tables==0.0.9
+sphinxcontrib-apidoc==0.3.0


### PR DESCRIPTION
Read The Docs builds but has an undesired output. This locks the versions of the dependencies for building to get back to a working version. Later on we may want to look at updating the docs build to be able to use more recent versions of these requirements.