### PR TITLE
Error comparing VCF files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
 - export CROMWELL_JAR=/tmp/cromwell-53.1.jar
 script:
 - make test
+- make quickstart
 - make test_release_setup
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -75,3 +75,6 @@ release: clean tag
 		-H "Authorization: token $(token)" \
 		https://api.github.com/repos/$(repo)/releases \
 		-d '{"tag_name":"$(version)","target_commitish": "main","name": "$(version)","body": "$(desc)","draft": false,"prerelease": false}'
+
+quickstart:
+	cd examples/quickstart && pytest -s -vv --show-capture=all

--- a/pytest_wdl/data_types/vcf.py
+++ b/pytest_wdl/data_types/vcf.py
@@ -54,7 +54,9 @@ def diff_vcf_columns(file1: Path, file2: Path, compare_phase: bool = False) -> i
     with tempdir() as temp:
         def make_comparable(infile, outfile):
             cmd = ["grep -vE '^#'", "cut -f 1-5,7,10", "cut -d ':' -f 1"]
-            output = subby.sub(cmd, stdin=infile)
+            # if the VCF file is empty or (for some reason) has no headers,
+            # grep will exit with return code 1
+            output = subby.sub(cmd, stdin=infile, allowed_return_codes=(0, 1))
             with open(outfile, "wt") as out:
                 if compare_phase:
                     out.write(output)


### PR DESCRIPTION
In the VCF data type, VCF files are made comparable using a grep command that filters out comment lines. If the file is empty or has no header lines, grep exits with a return code of 1, which should be allowed as valid.

This is the root cause of https://github.com/EliLillyCo/pytest-wdl/issues/158

